### PR TITLE
Fix AtomicParsley metadata injection crash caused by NUL comment

### DIFF
--- a/src/audio/metadata.rs
+++ b/src/audio/metadata.rs
@@ -166,7 +166,10 @@ pub async fn inject_metadata_atomicparsley(
         cmd.args(&["--composer", composer]);
     }
     if let Some(comment) = comment {
-        cmd.args(&["--comment", comment]);
+        let comment = comment.replace('\0', "");
+        if !comment.is_empty() {
+            cmd.args(&["--comment", &comment]);
+        }
     }
     if let Some(cover) = cover_art {
         cmd.args(&["--artwork", &cover.display().to_string()]);


### PR DESCRIPTION
Sanitize comment metadata by removing embedded NUL characters before invoking AtomicParsley. This prevents metadata injection from failing on files containing invalid comment tags.