### PR TITLE
Support FLAC file sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to audiobook-forge will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **FLAC source support** (#13): `.flac` files are now accepted as source tracks
+  and transcoded to AAC like MP3/M4A sources, enabling workflows that rip audio
+  CDs to FLAC for maximum fidelity. Track metadata (title, artist, album, track
+  number, etc.) is read from FLAC Vorbis comments via ffprobe.
+
+### Fixed
+- **Concat copy-mode codec check now uses an allowlist**: stream copy into the
+  M4B container is only attempted for codecs that live natively in MP4 (AAC,
+  ALAC). Previously only MP3 was blocklisted, so other non-MP4 codecs (e.g. FLAC)
+  would fall through to a failing `-c copy`.
+
 ## [2.11.0] - 2026-07-03
 
 ### Fixed

--- a/src/audio/metadata.rs
+++ b/src/audio/metadata.rs
@@ -55,8 +55,11 @@ pub fn extract_m4a_metadata(track: &mut Track) -> Result<()> {
 /// already a runtime dependency and exposes them under `format.tags`, so we reuse
 /// it rather than pulling in a new crate. Vorbis comment keys are conventionally
 /// uppercase but not case-canonical, so lookups are case-insensitive.
-pub fn extract_flac_metadata(track: &mut Track) -> Result<()> {
-    let output = std::process::Command::new("ffprobe")
+pub async fn extract_flac_metadata(track: &mut Track) -> Result<()> {
+    // Use tokio's async Command so this does not block the runtime worker thread
+    // when called from the parallel analysis pipeline, matching every other
+    // ffprobe/ffmpeg call site in the codebase.
+    let output = tokio::process::Command::new("ffprobe")
         .args([
             "-v", "quiet",
             "-print_format", "json",
@@ -64,6 +67,7 @@ pub fn extract_flac_metadata(track: &mut Track) -> Result<()> {
         ])
         .arg(&track.file_path)
         .output()
+        .await
         .context("Failed to execute ffprobe for FLAC metadata")?;
 
     if !output.status.success() {
@@ -108,13 +112,13 @@ pub fn extract_flac_metadata(track: &mut Track) -> Result<()> {
 }
 
 /// Extract metadata from any audio file (auto-detect format)
-pub fn extract_metadata(track: &mut Track) -> Result<()> {
+pub async fn extract_metadata(track: &mut Track) -> Result<()> {
     if track.is_mp3() {
         extract_mp3_metadata(track)
     } else if track.is_m4a() {
         extract_m4a_metadata(track)
     } else if track.is_flac() {
-        extract_flac_metadata(track)
+        extract_flac_metadata(track).await
     } else {
         // Unknown format - skip metadata extraction
         Ok(())

--- a/src/audio/metadata.rs
+++ b/src/audio/metadata.rs
@@ -49,12 +49,72 @@ pub fn extract_m4a_metadata(track: &mut Track) -> Result<()> {
     Ok(())
 }
 
+/// Extract metadata from a FLAC file via ffprobe (reads Vorbis comments).
+///
+/// FLAC tags are Vorbis comments, which id3/mp4ameta cannot read. ffprobe is
+/// already a runtime dependency and exposes them under `format.tags`, so we reuse
+/// it rather than pulling in a new crate. Vorbis comment keys are conventionally
+/// uppercase but not case-canonical, so lookups are case-insensitive.
+pub fn extract_flac_metadata(track: &mut Track) -> Result<()> {
+    let output = std::process::Command::new("ffprobe")
+        .args([
+            "-v", "quiet",
+            "-print_format", "json",
+            "-show_format",
+        ])
+        .arg(&track.file_path)
+        .output()
+        .context("Failed to execute ffprobe for FLAC metadata")?;
+
+    if !output.status.success() {
+        anyhow::bail!("ffprobe failed to read FLAC metadata");
+    }
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .context("Failed to parse ffprobe JSON output")?;
+
+    // Vorbis comment keys can be any case; collect them lowercased for lookup.
+    let tags: std::collections::HashMap<String, String> = json["format"]["tags"]
+        .as_object()
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.to_lowercase(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let get = |key: &str| tags.get(key).map(|s| s.to_string());
+
+    track.title = get("title");
+    track.artist = get("artist");
+    track.album = get("album");
+    // Vorbis convention is ALBUMARTIST; ffmpeg also maps to album_artist.
+    track.album_artist = get("albumartist").or_else(|| get("album_artist"));
+    track.genre = get("genre");
+    // Vorbis DATE is often a full date or just a year; take the leading 4 digits.
+    track.year = get("date")
+        .as_deref()
+        .and_then(|s| s.get(..4))
+        .and_then(|y| y.parse::<u32>().ok());
+    track.comment = get("comment").or_else(|| get("description"));
+    track.composer = get("composer");
+
+    // TRACKNUMBER may be "5" or "5/12"; take the part before the slash.
+    track.track_number = get("tracknumber")
+        .or_else(|| get("track"))
+        .and_then(|s| s.split('/').next().and_then(|n| n.trim().parse::<u32>().ok()));
+
+    Ok(())
+}
+
 /// Extract metadata from any audio file (auto-detect format)
 pub fn extract_metadata(track: &mut Track) -> Result<()> {
     if track.is_mp3() {
         extract_mp3_metadata(track)
     } else if track.is_m4a() {
         extract_m4a_metadata(track)
+    } else if track.is_flac() {
+        extract_flac_metadata(track)
     } else {
         // Unknown format - skip metadata extraction
         Ok(())

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -15,7 +15,7 @@ pub mod encoder;
 mod chapter_import;
 
 pub use ffmpeg::{FFmpeg, AudioMetadata};
-pub use metadata::{extract_metadata, extract_mp3_metadata, extract_m4a_metadata, inject_metadata_atomicparsley, inject_audible_metadata, extract_embedded_cover};
+pub use metadata::{extract_metadata, extract_mp3_metadata, extract_m4a_metadata, extract_flac_metadata, inject_metadata_atomicparsley, inject_audible_metadata, extract_embedded_cover};
 pub use chapters::{Chapter, generate_chapters_from_files, parse_cue_file, write_mp4box_chapters, inject_chapters_mp4box};
 pub use audible::{AudibleClient, detect_asin, clean_sequence};
 pub use encoder::{AacEncoder, get_encoder, EncoderDetector};

--- a/src/core/analyzer.rs
+++ b/src/core/analyzer.rs
@@ -40,7 +40,7 @@ impl Analyzer {
                 let mut track = Track::new(mp3_file.clone(), quality);
 
                 // Extract metadata
-                if let Err(e) = extract_metadata(&mut track) {
+                if let Err(e) = extract_metadata(&mut track).await {
                     tracing::warn!(
                         "Failed to extract metadata from {}: {}",
                         mp3_file.display(),

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -123,8 +123,8 @@ impl Scanner {
                 Some("m4b") => {
                     book.m4b_files.push(file_path);
                 }
-                Some("m4a") => {
-                    // M4A files are treated like MP3s (can be converted)
+                Some("m4a") | Some("flac") => {
+                    // These files are treated like MP3s (can be converted)
                     book.mp3_files.push(file_path);
                 }
                 Some("cue") => {

--- a/src/models/book.rs
+++ b/src/models/book.rs
@@ -144,9 +144,13 @@ impl BookFolder {
             return false;
         }
 
-        // MP3 codec cannot be copied into M4B container - must transcode to AAC
+        // Only codecs that live natively in an MP4/M4B container can be stream-copied.
+        // Everything else (mp3, flac, opus, vorbis, wav, ...) must be transcoded to
+        // AAC. Use an allowlist rather than blocklisting individual codecs so new
+        // source formats don't silently fall through to a failing `-c copy`.
         let first_codec = self.tracks[0].quality.codec.to_lowercase();
-        if first_codec == "mp3" || first_codec == "mp3float" {
+        let is_copyable = matches!(first_codec.as_str(), "aac" | "alac");
+        if !is_copyable {
             return false;
         }
 
@@ -310,5 +314,27 @@ mod tests {
         ];
 
         assert!(!book.can_use_concat_copy());
+
+        // FLAC cannot be stream-copied into an M4B container - must transcode.
+        let flac_quality1 = QualityProfile::new(900, 44100, 2, "flac".to_string(), 3600.0).unwrap();
+        let flac_quality2 = QualityProfile::new(900, 44100, 2, "flac".to_string(), 1800.0).unwrap();
+
+        book.tracks = vec![
+            Track::new(PathBuf::from("1.flac"), flac_quality1),
+            Track::new(PathBuf::from("2.flac"), flac_quality2),
+        ];
+
+        assert!(!book.can_use_concat_copy());
+
+        // ALAC lives natively in MP4/M4B, so it remains copyable.
+        let alac_quality1 = QualityProfile::new(900, 44100, 2, "alac".to_string(), 3600.0).unwrap();
+        let alac_quality2 = QualityProfile::new(900, 44100, 2, "alac".to_string(), 1800.0).unwrap();
+
+        book.tracks = vec![
+            Track::new(PathBuf::from("1.m4a"), alac_quality1),
+            Track::new(PathBuf::from("2.m4a"), alac_quality2),
+        ];
+
+        assert!(book.can_use_concat_copy());
     }
 }

--- a/src/models/track.rs
+++ b/src/models/track.rs
@@ -75,6 +75,11 @@ impl Track {
     pub fn is_m4a(&self) -> bool {
         matches!(self.get_extension().as_deref(), Some("m4a" | "m4b"))
     }
+
+    /// Check if this is a FLAC file
+    pub fn is_flac(&self) -> bool {
+        matches!(self.get_extension().as_deref(), Some("flac"))
+    }
 }
 
 #[cfg(test)]
@@ -101,5 +106,15 @@ mod tests {
         assert!(track_m4a.is_m4a());
         assert!(track_m4b.is_m4a());
         assert!(!track_m4a.is_mp3());
+    }
+
+    #[test]
+    fn test_flac_extension() {
+        let quality = QualityProfile::new(900, 44100, 2, "flac".to_string(), 3600.0).unwrap();
+        let track = Track::new(PathBuf::from("/path/to/track.flac"), quality);
+
+        assert!(track.is_flac());
+        assert!(!track.is_mp3());
+        assert!(!track.is_m4a());
     }
 }


### PR DESCRIPTION
## Description

Adds FLAC as a supported source format. `.flac` files are accepted as source tracks and transcoded to AAC, the same way MP3/M4A sources are handled. This supports ripping audio CDs to FLAC for maximum fidelity and then building an M4B.

Builds on @xanium4332's scanner change in #13 (credited via `Co-authored-by`), and completes the feature with the parts that were missing to make FLAC work end to end.

## What #13 was missing

The one-line scanner change routed FLAC into the convertible pool, but two things downstream would have failed silently:

1. **FLAC metadata was dropped.** `extract_metadata` routed by `is_mp3()` / `is_m4a()`; a FLAC matched neither and hit the "unknown format, skip" branch with no warning. All FLAC tags (title, artist, album, and crucially **track number**) were discarded, which breaks CD track ordering and M4B naming.
2. **Copy mode would fail.** `can_use_concat_copy` only blocklisted `mp3`, so an all-FLAC book returned `true` and would attempt `-c copy` of a FLAC stream into an M4B container, which is invalid.

## Changes

- `extract_flac_metadata`: reads FLAC Vorbis comments (title, artist, album, albumartist, genre, date, comment, composer, tracknumber) via ffprobe. No new dependency — ffprobe is already a runtime dependency. Handles case-insensitive Vorbis keys and `TRACKNUMBER` of the form `5/12`.
- `Track::is_flac()` and routing in `extract_metadata`.
- `can_use_concat_copy` switched from blocklisting `mp3` to an **allowlist** (`aac`, `alac`) — the only codecs that live natively in MP4/M4B. This fixes FLAC and prevents the same class of bug for any future non-MP4 source format.
- Scanner change from #13 (route `.flac` to the convertible pool).

## Testing

- `test_flac_extension`, extended `test_can_use_concat_copy` (FLAC not copyable, ALAC copyable), plus the full suite green (129 lib + all integration tests). `cargo clippy` clean on the new code.
- Note: `extract_flac_metadata` is not unit-tested against a real FLAC (no test fixtures with embedded tags in the repo), consistent with how the other ffprobe/tag-reading paths are covered.

Closes #13
