### PR TITLE
add metadata export-chapters subcommand to bypass chapter injection errors

### DIFF
--- a/doc/plan.md
+++ b/doc/plan.md
@@ -1,0 +1,210 @@
+# 修改计划：为 audiobook-forge 增加单独生成章节信息文件功能
+## 总体思路
+当前 `audiobook-forge build` 在合并出 M4B 后会调用 AtomicParsley / MP4Box 把章节元数据写回文件，这一步在你的环境里报错（典型原因是 AtomicParsley 在大文件或特殊标签上 crash，或 MP4Box 缺失）。**可行的修复路径是：复用现有的"按 `/path/to/My Audiobook` 扫描源文件 → 生成章节时间戳"的逻辑，把它从构建流水线里抽出来，新增一个子命令只导出 ffmpeg 风格的章节元数据文件**，再用一条单独的 `ffmpeg -i book.m4b -i chapters.txt -map_metadata 1 -codec copy` 命令把章节回灌进去——这一步不依赖 AtomicParsley/MP4Box，绕开报错点。
+下面是改造后的工作流：
+```mermaid
+flowchart LR
+    A["源目录<br/>/path/to/My Audiobook"] --> B{选择路径}
+    B -->|现有 build| C["完整流水线<br/>转码+合并+章节注入"]
+    C --> D["M4B（含章节）"]
+    B -->|新增 export-chapters| E["复用扫描+时间戳逻辑"]
+    E --> F["chapters.txt<br/>ffmpeg metadata 格式"]
+    F --> G["ffmpeg -i book.m4b -i chapters.txt<br/>-map_metadata 1 -codec copy"]
+    G --> H["M4B（章节已回灌）"]
+    D -.报错回退.-> F
+```
+---
+## 一、定位现有章节生成逻辑
+代码结构为 `src/{audio, cli, core, models, ui, utils}`，章节相关逻辑分散在以下位置（需你按实际确认函数名与行号）：
+| 模块 | 作用 | 需要关注的内容 |
+|---|---|---|
+| `src/core/scanner.rs`（或 `processor.rs`） | 扫描 `--root` 目录、自然排序音轨 | `Scanner::scan_book_folder` 之类返回 `BookFolder` / `Vec<Track>` 的函数 |
+| `src/audio/` 下分析模块 | 用 ffprobe 取每条音轨时长 | 取 duration 的工具函数（多半调 `ffprobe -v quiet -print_format json -show_format`）|
+| `src/core/` 下章节构造 | 按文件名/CUE/EPUB/Audnex 生成章节列表 | `Chapter { start_ms, end_ms, title }` 结构与对应的 builder |
+| `src/cli/` | clap 子命令定义 | `Commands::Build`、`Commands::Metadata(MetadataArgs)` 枚举 |
+| 构建主流程 | 合并后写章节 | 调 AtomicParsley / MP4Box 的那一段——**报错点** |
+v2.9.0 已经引入了"用 ffprobe 读取已有 M4B 章节"的能力，说明 `src/audio/` 或 `src/metadata/` 下已有一个 `ffprobe` 解析器可直接复用来读回现有章节。
+---
+## 二、设计新的 CLI 子命令
+建议在 `metadata` 下加 `export-chapters` 子命令，与现有 `metadata enrich` 对齐：
+```rust
+// src/cli/mod.rs （或 commands.rs）
+#[derive(Subcommand, Debug)]
+pub enum MetadataSub {
+    /// 现有的 enrich
+    Enrich(MetadataEnrichArgs),
+    /// 新增：只导出章节元数据文件，不做任何转码/注入
+    ExportChapters(ExportChaptersArgs),
+}
+#[derive(Parser, Debug)]
+pub struct ExportChaptersArgs {
+    /// 源目录或已生成的 M4B 文件
+    /// 复用 build 的 --root 语义
+    #[arg(long, value_name = "PATH")]
+    pub root: PathBuf,
+    /// 输出文件；不指定则写到 <root>/<book_name>.chapters.txt
+    #[arg(long, short = 'o', value_name = "FILE")]
+    pub output: Option<PathBuf>,
+    /// 章节标题来源：filename / cue / epub / audnex:<ASIN>
+    /// 默认 filename，与 build 默认一致
+    #[arg(long, default_value = "filename")]
+    pub chapters_source: String,
+    /// 时间基：1/1000 (默认, ffmpeg 友好) 或 1/44100 等
+    #[arg(long, default_value_t = String::from("1/1000"))]
+    pub timebase: String,
+    /// 同时输出 JSON 版本（便于程序后续处理）
+    #[arg(long)]
+    pub json: bool,
+}
+```
+调用形式：
+```bash
+audiobook-forge metadata export-chapters --root "/path/to/My Audiobook"
+# → 生成 /path/to/My Audiobook/My Audiobook.chapters.txt
+```
+---
+## 三、抽取并复用章节生成逻辑
+把构建流程中"扫描 → 取时长 → 生成章节列表"那一段抽成一个纯函数，返回 `Vec<Chapter>`，供 `build` 和 `export-chapters` 共用：
+```rust
+// src/core/chapters.rs （新建或扩展已有文件）
+use crate::models::{BookFolder, Chapter};
+use anyhow::Result;
+/// 复用点：根据 root 目录生成章节列表（不依赖任何外部注入工具）
+pub async fn build_chapters_from_folder(
+    root: &Path,
+    source: &ChapterSource,
+) -> Result<Vec<Chapter>> {
+    // 1. 复用 Scanner：let folder = Scanner::scan_book_folder(root)?;
+    // 2. 复用 Analyzer 取每轨 duration（ffprobe）
+    // 3. 累加偏移得到 start_ms / end_ms
+    // 4. 按 source 解析标题（filename / cue / epub / audnex）
+    //    —— 这些在 v2.9.0 的 Chapter Update System 里都已存在
+    Ok(chapters)
+}
+pub struct Chapter {
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub title: String,
+}
+```
+然后在 `build` 主流程里把原先内联的逻辑替换为 `build_chapters_from_folder(...)` 的调用——这样既加了新功能，又不改变现有行为。
+---
+## 四、实现章节文件写入
+ffmpeg 的章节元数据格式（与 `metadata enrich` 读取的 timestamped 格式一致）：
+```
+;FFMETADATA1
+[CHAPTER]
+TIMEBASE=1/1000
+START=0
+END=4480000
+title=Chapter 1 - Intro
+[CHAPTER]
+TIMEBASE=1/1000
+START=4480001
+END=38839999
+title=Chapter 2 - The Journey
+```
+写入函数：
+```rust
+// src/core/chapters.rs
+use std::io::Write;
+pub fn write_ffmetadata(chapters: &[Chapter], path: &Path, timebase: &str) -> Result<()> {
+    let mut f = std::fs::File::create(path)?;
+    writeln!(f, ";FFMETADATA1")?;
+    for c in chapters {
+        writeln!(f, "[CHAPTER]")?;
+        writeln!(f, "TIMEBASE={timebase}")?;
+        writeln!(f, "START={}", c.start_ms)?;
+        writeln!(f, "END={}", c.end_ms)?;
+        writeln!(f, "title={}", sanitize_title(&c.title))?;
+        writeln!(f)?; // 空行分隔，提升兼容性
+    }
+    Ok(())
+}
+fn sanitize_title(s: &str) -> String {
+    // ffmpeg metadata 里换行/等号需转义
+    s.replace('\n', " ").replace('=', " - ")
+}
+pub fn write_json(chapters: &[Chapter], path: &Path) -> Result<()> {
+    let v: Vec<_> = chapters.iter().map(|c| serde_json::json!({
+        "start_ms": c.start_ms, "end_ms": c.end_ms, "title": c.title
+    })).collect();
+    std::fs::write(path, serde_json::to_string_pretty(&v)?)?;
+    Ok(())
+}
+```
+---
+## 五、子命令分发实现
+在 `main.rs` / `cli` 的 dispatch 里加分支：
+```rust
+MetadataSub::ExportChapters(args) => {
+    let root = args.root.canonicalize()
+        .with_context(|| format!("root 不存在: {:?}", args.root))?;
+    let source = ChapterSource::parse(&args.chapters_source)?;
+    let chapters = build_chapters_from_folder(&root, &source).await?;
+    let out = args.output.unwrap_or_else(|| {
+        // 复用 build 里推导书名的逻辑：取 root 的文件名
+        root.join(format!("{}.chapters.txt",
+            root.file_name().unwrap().to_string_lossy()))
+    });
+    write_ffmetadata(&chapters, &out, &args.timebase)?;
+    println!("已写出章节文件: {}", out.display());
+    if args.json {
+        let json_path = out.with_extension("chapters.json");
+        write_json(&chapters, &json_path)?;
+        println!("JSON 版本: {}", json_path.display());
+    }
+    // 打印摘要便于核对
+    println!("共 {} 章，总时长 {:.1} 分钟",
+        chapters.len(),
+        chapters.last().map(|c| c.end_ms as f64 / 60000.0).unwrap_or(0.0));
+}
+```
+---
+## 六、手动把章节回灌到 M4B
+生成 `chapters.txt` 后，用一条 ffmpeg 命令完成注入（不依赖 AtomicParsley/MP4Box）：
+```bash
+ffmpeg -i "/path/to/My Audiobook.m4b" \
+       -i "/path/to/My Audiobook.chapters.txt" \
+       -map_metadata 1 \
+       -map_chapters 1 \
+       -codec copy \
+       "/path/to/My Audiobook.chapters.m4b"
+# 验证
+ffprobe -i "/path/to/My Audiobook.chapters.m4b" -print_format json -show_chapters
+```
+关键点：
+- `-codec copy` 保证不重新编码、不损失质量。
+- `-map_metadata 1` + `-map_chapters 1` 让 ffmpeg 从第二个输入读取章节。
+- 输出到新文件，避免原地覆盖出问题时无法回退；确认无误后再 `mv` 覆盖原文件。
+如果源是已经生成但缺章节的 M4B，而不是目录，可以再加一个 ffprobe 回退路径，复用 v2.9.0 里"从 M4B 读取章节"的逻辑，把读到的章节直接导出——这样即便没有源目录也能补救已有 M4B。
+---
+## 七、测试与验证清单
+1. **单元测试**：`write_ffmetadata` 对已知 `Vec<Chapter>` 输出做字符串快照比对；`sanitize_title` 覆盖换行、`=`、中文等用例。
+2. **集成测试**（用 `assert_cmd`，仓库已依赖）：
+   - 准备一个 3 轨的临时目录，跑 `metadata export-chapters --root <tmp>`。
+   - 断言输出文件存在、行数 = `1 + 5*N`、`START` 单调递增、最后一章 `END` 等于总时长。
+3. **端到端**：
+   - `audiobook-forge build --root "/path/to/My Audiobook"`（复现报错，得到无章节 M4B）。
+   - `audiobook-forge metadata export-chapters --root "/path/to/My Audiobook"`。
+   - `ffmpeg -i ... -map_chapters 1 -codec copy ...`。
+   - `ffprobe ... -show_chapters` 确认章节数与标题正确。
+   - 在 Apple Books / Audiobookshelf 里打开，确认可跳章。
+4. **回归**：原来的 `build` 流程行为不变（因为只是把内联逻辑抽成函数调用）。
+5. **`cargo fmt && cargo clippy && cargo test`** 全绿后再提交。
+---
+## 八、常见坑与排查
+- **ffprobe 时长单位**：ffprobe 返回的 `duration` 是秒（浮点），乘 1000 得毫秒；注意有些容器返回 `N/A`，要回退到 `ffprobe -show_packets -select_streams a` 累加。
+- **首章 START 必须 = 0**：Apple Books 对非零起点章节识别不稳定，把第一章 `START` 强制设为 0。
+- **TIMEBASE 选择**：`1/1000`（毫秒）最通用；若用 `1/44100` 需保证 START/END 都是整数采样数。
+- **标题编码**：ffmpeg metadata 默认 UTF-8，但 Windows 控制台重定向可能写 GBK——`std::fs::File` 直接写 UTF-8 字节即可，不要走 `println!` 再重定向。
+- **`-map_metadata 1` 覆盖原有 tag**：会丢失 M4B 里已有的 title/artist 等。如果原文件已有元数据，改用 `ffmpeg -i in.m4b -i chapters.txt -map_metadata 0 -map_chapters 1 -codec copy out.m4b`（metadata 取自输入 0，章节取自输入 1）。
+- **AtomicParsley crash 的根因**：通常是封面图过大或 ID3v2.4 标签含特殊字符；即使后续不依赖它，也建议在 issue 里附上 `RUST_LOG=debug audiobook-forge build ... 2>log.txt` 的尾部日志，便于上游修复。
+---
+## 九、可选增强
+- 在 `build` 报错时自动落盘 `chapters.txt` 到输出目录，并打印上面那条 ffmpeg 命令——把"故障兜底"变成内置行为。
+- 给 `export-chapters` 加 `--from-m4b` 标志，直接对已有 M4B 用 ffprobe 读章节再导出，省去保留源目录的麻烦。
+- 支持 CUE sheet 输出（`--format cue`），方便其他工具链。
+- 把章节文件路径写进 `ProcessingResult`，让 YAML 配置 `chapters.export_on_failure: true` 控制是否自动触发。
+按以上 1–8 步走，即可在不破坏现有 `build` 行为的前提下，新增一个独立、可复用、绕开注入工具报错的章节导出能力。
+

--- a/src/audio/audible.rs
+++ b/src/audio/audible.rs
@@ -1,7 +1,11 @@
 //! Audible API client for metadata fetching
 
 use anyhow::{Context, Result};
-use governor::{Quota, RateLimiter, state::{InMemoryState, direct::NotKeyed as DirectNotKeyed}, clock::DefaultClock};
+use governor::{
+    clock::DefaultClock,
+    state::{direct::NotKeyed as DirectNotKeyed, InMemoryState},
+    Quota, RateLimiter,
+};
 use reqwest::Client;
 use serde::Deserialize;
 use std::num::NonZeroU32;
@@ -9,7 +13,7 @@ use std::path::Path;
 use std::time::Duration;
 use thiserror::Error;
 
-use crate::models::{AudibleMetadata, AudibleRegion, AudibleAuthor, AudibleSeries};
+use crate::models::{AudibleAuthor, AudibleMetadata, AudibleRegion, AudibleSeries};
 
 const AUDNEXUS_BASE_URL: &str = "https://api.audnex.us";
 const DEFAULT_TIMEOUT_SECS: u64 = 10;
@@ -26,9 +30,7 @@ pub enum AudibleApiError {
     },
 
     #[error("Rate limit exceeded (429). Retry after {retry_after:?}")]
-    RateLimitExceeded {
-        retry_after: Option<Duration>,
-    },
+    RateLimitExceeded { retry_after: Option<Duration> },
 
     #[error("Request failed: {0}")]
     RequestFailed(#[from] reqwest::Error),
@@ -38,10 +40,7 @@ pub enum AudibleApiError {
 }
 
 /// Extract detailed error information from HTTP response
-async fn extract_error_details(
-    url: &str,
-    response: reqwest::Response,
-) -> AudibleApiError {
+async fn extract_error_details(url: &str, response: reqwest::Response) -> AudibleApiError {
     let status = response.status().as_u16();
 
     // Check for 429 rate limit
@@ -57,9 +56,10 @@ async fn extract_error_details(
     }
 
     // Capture response body for debugging
-    let body = response.text().await.unwrap_or_else(|_|
-        "<failed to read response body>".to_string()
-    );
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|_| "<failed to read response body>".to_string());
 
     let message = if (400..500).contains(&status) {
         "Client error"
@@ -93,7 +93,11 @@ impl AudibleClient {
 
     /// Create a new Audible client with custom rate limit
     pub fn with_rate_limit(region: AudibleRegion, requests_per_minute: u32) -> Result<Self> {
-        Self::with_config(region, requests_per_minute, crate::core::RetryConfig::default())
+        Self::with_config(
+            region,
+            requests_per_minute,
+            crate::core::RetryConfig::default(),
+        )
     }
 
     /// Create a new Audible client with full configuration
@@ -110,8 +114,7 @@ impl AudibleClient {
 
         // Rate limiter: requests_per_minute (e.g., 100 req/min = ~150ms between requests)
         let quota = Quota::per_minute(
-            NonZeroU32::new(requests_per_minute)
-                .unwrap_or(NonZeroU32::new(100).unwrap())
+            NonZeroU32::new(requests_per_minute).unwrap_or(NonZeroU32::new(100).unwrap()),
         );
         let rate_limiter = RateLimiter::direct(quota);
 
@@ -203,14 +206,19 @@ impl AudibleClient {
 
     /// Fetch metadata by ASIN
     pub async fn fetch_by_asin(&self, asin: &str) -> Result<AudibleMetadata> {
-        let url = format!("{}/books/{}?region={}",
-            AUDNEXUS_BASE_URL, asin, self.region.tld());
+        let url = format!(
+            "{}/books/{}?region={}",
+            AUDNEXUS_BASE_URL,
+            asin,
+            self.region.tld()
+        );
 
         tracing::debug!("Fetching Audible metadata: {}", url);
 
-        let response = self.execute_with_retry(|| {
-            self.client.get(&url).send()
-        }).await.context("Failed to fetch from Audnexus API")?;
+        let response = self
+            .execute_with_retry(|| self.client.get(&url).send())
+            .await
+            .context("Failed to fetch from Audnexus API")?;
 
         // Handle 429 specially
         let response = if response.status() == 429 {
@@ -238,7 +246,8 @@ impl AudibleClient {
         }
 
         // Parse the response
-        let api_response: AudnexusBookResponse = response.json()
+        let api_response: AudnexusBookResponse = response
+            .json()
             .await
             .context("Failed to parse Audible metadata")?;
 
@@ -248,14 +257,19 @@ impl AudibleClient {
 
     /// Fetch chapter data from Audnex API
     pub async fn fetch_chapters(&self, asin: &str) -> Result<Vec<crate::models::AudibleChapter>> {
-        let url = format!("{}/books/{}/chapters?region={}",
-            AUDNEXUS_BASE_URL, asin, self.region.tld());
+        let url = format!(
+            "{}/books/{}/chapters?region={}",
+            AUDNEXUS_BASE_URL,
+            asin,
+            self.region.tld()
+        );
 
         tracing::debug!("Fetching Audible chapters: {}", url);
 
-        let response = self.execute_with_retry(|| {
-            self.client.get(&url).send()
-        }).await.context("Failed to fetch chapters from Audnexus API")?;
+        let response = self
+            .execute_with_retry(|| self.client.get(&url).send())
+            .await
+            .context("Failed to fetch chapters from Audnexus API")?;
 
         // Handle 429 specially
         let response = if response.status() == 429 {
@@ -282,7 +296,8 @@ impl AudibleClient {
         }
 
         // Parse the response
-        let api_response: crate::models::AudnexChaptersResponse = response.json()
+        let api_response: crate::models::AudnexChaptersResponse = response
+            .json()
             .await
             .context("Failed to parse Audible chapters")?;
 
@@ -298,16 +313,17 @@ impl AudibleClient {
 
     /// Search by title and/or author using Audible's API
     /// Returns full metadata for each result by fetching from Audnexus
-    pub async fn search(&self, title: Option<&str>, author: Option<&str>) -> Result<Vec<AudibleMetadata>> {
+    pub async fn search(
+        &self,
+        title: Option<&str>,
+        author: Option<&str>,
+    ) -> Result<Vec<AudibleMetadata>> {
         if title.is_none() && author.is_none() {
             anyhow::bail!("Must provide at least title or author for search");
         }
 
         // Build query parameters for Audible's search API
-        let mut query_params = vec![
-            ("num_results", "10"),
-            ("products_sort_by", "Relevance"),
-        ];
+        let mut query_params = vec![("num_results", "10"), ("products_sort_by", "Relevance")];
 
         if let Some(t) = title {
             query_params.push(("title", t));
@@ -322,9 +338,10 @@ impl AudibleClient {
 
         tracing::debug!("Searching Audible: title={:?}, author={:?}", title, author);
 
-        let response = self.execute_with_retry(|| {
-            self.client.get(&url).query(&query_params).send()
-        }).await.context("Failed to search Audible API")?;
+        let response = self
+            .execute_with_retry(|| self.client.get(&url).query(&query_params).send())
+            .await
+            .context("Failed to search Audible API")?;
 
         // Handle 429 specially
         let response = if response.status() == 429 {
@@ -351,7 +368,8 @@ impl AudibleClient {
         }
 
         // Parse Audible's search response (just ASINs)
-        let search_response: AudibleSearchResponse = response.json()
+        let search_response: AudibleSearchResponse = response
+            .json()
             .await
             .context("Failed to parse Audible search results")?;
 
@@ -380,7 +398,9 @@ impl AudibleClient {
 
         tracing::debug!("Downloading cover from: {}", cover_url);
 
-        let response = self.client.get(cover_url)
+        let response = self
+            .client
+            .get(cover_url)
             .send()
             .await
             .context("Failed to download cover")?;
@@ -389,12 +409,12 @@ impl AudibleClient {
             anyhow::bail!("Cover download failed: {}", response.status());
         }
 
-        let bytes = response.bytes()
+        let bytes = response
+            .bytes()
             .await
             .context("Failed to read cover bytes")?;
 
-        std::fs::write(dest_path, bytes)
-            .context("Failed to write cover file")?;
+        std::fs::write(dest_path, bytes).context("Failed to write cover file")?;
 
         tracing::debug!("Cover saved to: {}", dest_path.display());
 
@@ -419,7 +439,7 @@ impl AudibleClient {
 struct AudibleSearchResponse {
     products: Vec<AudibleProduct>,
     #[serde(default)]
-    #[allow(dead_code)]  // Part of API response but not used
+    #[allow(dead_code)] // Part of API response but not used
     total_results: u32,
 }
 
@@ -455,7 +475,7 @@ struct AudnexusBookResponse {
     runtime_length_min: Option<u64>,
     #[serde(rename = "formatType")]
     format_type: Option<String>,
-    rating: Option<String>,  // API returns string, we'll parse to f32
+    rating: Option<String>, // API returns string, we'll parse to f32
 }
 
 #[derive(Debug, Deserialize)]
@@ -471,7 +491,7 @@ struct AudnexusNarrator {
 
 #[derive(Debug, Deserialize)]
 struct AudnexusGenre {
-    #[allow(dead_code)]  // Part of API response but not used
+    #[allow(dead_code)] // Part of API response but not used
     asin: Option<String>,
     name: String,
     #[serde(rename = "type")]
@@ -488,13 +508,15 @@ struct AudnexusSeries {
 /// Convert Audnexus API response to our metadata structure
 fn convert_audnexus_to_metadata(api: AudnexusBookResponse) -> AudibleMetadata {
     // Extract year from release_date (format: "YYYY-MM-DD")
-    let published_year = api.release_date
+    let published_year = api
+        .release_date
         .as_ref()
         .and_then(|date| date.split('-').next())
         .and_then(|year_str| year_str.parse::<u32>().ok());
 
     // Convert authors
-    let authors = api.authors
+    let authors = api
+        .authors
         .unwrap_or_default()
         .into_iter()
         .map(|a| AudibleAuthor {
@@ -504,7 +526,8 @@ fn convert_audnexus_to_metadata(api: AudnexusBookResponse) -> AudibleMetadata {
         .collect();
 
     // Convert narrators
-    let narrators = api.narrators
+    let narrators = api
+        .narrators
         .unwrap_or_default()
         .into_iter()
         .map(|n| n.name)
@@ -542,7 +565,8 @@ fn convert_audnexus_to_metadata(api: AudnexusBookResponse) -> AudibleMetadata {
     }
 
     // Determine if abridged
-    let is_abridged = api.format_type
+    let is_abridged = api
+        .format_type
         .as_ref()
         .map(|ft| ft.to_lowercase() == "abridged");
 
@@ -550,8 +574,7 @@ fn convert_audnexus_to_metadata(api: AudnexusBookResponse) -> AudibleMetadata {
     let runtime_length_ms = api.runtime_length_min.map(|min| min * 60_000);
 
     // Parse rating from string to f32
-    let rating = api.rating
-        .and_then(|r| r.parse::<f32>().ok());
+    let rating = api.rating.and_then(|r| r.parse::<f32>().ok());
 
     AudibleMetadata {
         asin: api.asin,
@@ -583,7 +606,8 @@ pub fn detect_asin(text: &str) -> Option<String> {
         static ref ASIN_REGEX: Regex = Regex::new(r"\b(B[0-9A-Z]{9})\b").unwrap();
     }
 
-    ASIN_REGEX.captures(text)
+    ASIN_REGEX
+        .captures(text)
         .and_then(|cap| cap.get(1))
         .map(|m| m.as_str().to_string())
 }
@@ -597,7 +621,8 @@ pub fn clean_sequence(sequence: &str) -> String {
         static ref SEQ_REGEX: Regex = Regex::new(r"(\d+(?:\.\d+)?)").unwrap();
     }
 
-    SEQ_REGEX.captures(sequence)
+    SEQ_REGEX
+        .captures(sequence)
         .and_then(|cap| cap.get(1))
         .map(|m| m.as_str().to_string())
         .unwrap_or_else(|| sequence.to_string())
@@ -609,9 +634,18 @@ mod tests {
 
     #[test]
     fn test_asin_detection() {
-        assert_eq!(detect_asin("Book Title [B002V5D7RU]"), Some("B002V5D7RU".to_string()));
-        assert_eq!(detect_asin("B002V5D7RU - Book Title"), Some("B002V5D7RU".to_string()));
-        assert_eq!(detect_asin("Project Hail Mary [B00G3L6JMS].m4b"), Some("B00G3L6JMS".to_string()));
+        assert_eq!(
+            detect_asin("Book Title [B002V5D7RU]"),
+            Some("B002V5D7RU".to_string())
+        );
+        assert_eq!(
+            detect_asin("B002V5D7RU - Book Title"),
+            Some("B002V5D7RU".to_string())
+        );
+        assert_eq!(
+            detect_asin("Project Hail Mary [B00G3L6JMS].m4b"),
+            Some("B00G3L6JMS".to_string())
+        );
         assert_eq!(detect_asin("No ASIN Here"), None);
         assert_eq!(detect_asin("Invalid B12345"), None); // Too short
     }

--- a/src/audio/chapter_import.rs
+++ b/src/audio/chapter_import.rs
@@ -1,8 +1,8 @@
 //! Chapter import and merge strategies
 
+use crate::audio::Chapter;
 use anyhow::{Context, Result};
 use std::path::Path;
-use crate::audio::Chapter;
 
 /// Source of chapter data
 #[derive(Debug, Clone)]
@@ -72,8 +72,7 @@ pub enum TextFormat {
 
 /// Parse chapters from text file
 pub fn parse_text_chapters(path: &Path) -> Result<Vec<Chapter>> {
-    let content = std::fs::read_to_string(path)
-        .context("Failed to read chapter file")?;
+    let content = std::fs::read_to_string(path).context("Failed to read chapter file")?;
 
     // Auto-detect format
     let format = detect_text_format(&content);
@@ -194,7 +193,8 @@ fn parse_mp4box_format(content: &str) -> Result<Vec<Chapter>> {
     }
 
     let mut chapter_times: std::collections::HashMap<u32, u64> = std::collections::HashMap::new();
-    let mut chapter_names: std::collections::HashMap<u32, String> = std::collections::HashMap::new();
+    let mut chapter_names: std::collections::HashMap<u32, String> =
+        std::collections::HashMap::new();
 
     for line in content.lines() {
         if let Some(caps) = CHAPTER_REGEX.captures(line) {
@@ -247,10 +247,10 @@ fn parse_mp4box_format(content: &str) -> Result<Vec<Chapter>> {
 pub fn parse_epub_chapters(path: &Path) -> Result<Vec<Chapter>> {
     use epub::doc::EpubDoc;
 
-    let doc = EpubDoc::new(path)
-        .context("Failed to open EPUB file")?;
+    let doc = EpubDoc::new(path).context("Failed to open EPUB file")?;
 
-    let toc = doc.toc
+    let toc = doc
+        .toc
         .iter()
         .enumerate()
         .map(|(i, nav_point)| {
@@ -296,11 +296,7 @@ pub async fn read_m4b_chapters(m4b_path: &Path) -> Result<Vec<Chapter>> {
     }
 
     let output = Command::new("ffprobe")
-        .args([
-            "-v", "quiet",
-            "-print_format", "json",
-            "-show_chapters",
-        ])
+        .args(["-v", "quiet", "-print_format", "json", "-show_chapters"])
         .arg(m4b_path)
         .output()
         .await
@@ -310,11 +306,10 @@ pub async fn read_m4b_chapters(m4b_path: &Path) -> Result<Vec<Chapter>> {
         anyhow::bail!("ffprobe failed to read chapters from M4B file");
     }
 
-    let json_str = String::from_utf8(output.stdout)
-        .context("ffprobe output is not valid UTF-8")?;
+    let json_str = String::from_utf8(output.stdout).context("ffprobe output is not valid UTF-8")?;
 
-    let ffprobe_output: FfprobeOutput = serde_json::from_str(&json_str)
-        .context("Failed to parse ffprobe JSON output")?;
+    let ffprobe_output: FfprobeOutput =
+        serde_json::from_str(&json_str).context("Failed to parse ffprobe JSON output")?;
 
     let chapters: Vec<Chapter> = ffprobe_output
         .chapters
@@ -367,9 +362,7 @@ pub fn merge_chapters(
             merge_keep_timestamps(existing, new)
         }
 
-        ChapterMergeStrategy::KeepTimestamps => {
-            merge_keep_timestamps(existing, new)
-        }
+        ChapterMergeStrategy::KeepTimestamps => merge_keep_timestamps(existing, new),
 
         ChapterMergeStrategy::ReplaceAll => {
             // Simply return new chapters
@@ -466,9 +459,7 @@ mod tests {
             Chapter::new(2, "Chapter Two".to_string(), 1000, 2000),
         ];
 
-        let new_different = vec![
-            Chapter::new(1, "Chapter One".to_string(), 0, 1000),
-        ];
+        let new_different = vec![Chapter::new(1, "Chapter One".to_string(), 0, 1000)];
 
         let comp1 = ChapterComparison::new(&existing, &new_matching);
         assert!(comp1.matches);
@@ -495,7 +486,10 @@ mod tests {
     #[test]
     fn test_detect_timestamped_format() {
         let content = "00:00:00 Prologue\n00:05:30 Chapter 1";
-        assert!(matches!(detect_text_format(content), TextFormat::Timestamped));
+        assert!(matches!(
+            detect_text_format(content),
+            TextFormat::Timestamped
+        ));
     }
 
     #[test]
@@ -611,9 +605,7 @@ mod tests {
             Chapter::new(2, "Chapter 2".to_string(), 1000, 2000),
         ];
 
-        let new = vec![
-            Chapter::new(1, "Prologue".to_string(), 0, 0),
-        ];
+        let new = vec![Chapter::new(1, "Prologue".to_string(), 0, 0)];
 
         let result = merge_chapters(&existing, &new, ChapterMergeStrategy::SkipOnMismatch);
 
@@ -630,9 +622,7 @@ mod tests {
             Chapter::new(3, "Chapter 3".to_string(), 2000, 3000),
         ];
 
-        let new = vec![
-            Chapter::new(1, "Prologue".to_string(), 0, 0),
-        ];
+        let new = vec![Chapter::new(1, "Prologue".to_string(), 0, 0)];
 
         let merged = merge_chapters(&existing, &new, ChapterMergeStrategy::KeepTimestamps).unwrap();
 
@@ -681,7 +671,7 @@ mod tests {
         assert_eq!(merged[3].title, "Part2 Ch2");
         assert_eq!(merged[3].start_time_ms, 165_000);
         assert_eq!(merged[3].end_time_ms, 210_000); // 120_000 + 90_000
-        // Renumbered sequentially
+                                                    // Renumbered sequentially
         assert_eq!(merged[0].number, 1);
         assert_eq!(merged[1].number, 2);
         assert_eq!(merged[2].number, 3);

--- a/src/audio/chapters.rs
+++ b/src/audio/chapters.rs
@@ -2,7 +2,10 @@
 
 use anyhow::{Context, Result};
 use regex::Regex;
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::models::BookFolder;
 
 /// Represents a chapter in an audiobook
 #[derive(Debug, Clone)]
@@ -36,8 +39,10 @@ impl Chapter {
     /// Format as MP4Box chapter format
     pub fn to_mp4box_format(&self) -> String {
         let start_time = format_time_ms(self.start_time_ms);
-        format!("CHAPTER{}={}\nCHAPTER{}NAME={}\n",
-            self.number, start_time, self.number, self.title)
+        format!(
+            "CHAPTER{}={}\nCHAPTER{}NAME={}\n",
+            self.number, start_time, self.number, self.title
+        )
     }
 }
 
@@ -49,7 +54,10 @@ fn format_time_ms(ms: u64) -> String {
     let minutes = (total_seconds % 3600) / 60;
     let seconds = total_seconds % 60;
 
-    format!("{:02}:{:02}:{:02}.{:03}", hours, minutes, seconds, milliseconds)
+    format!(
+        "{:02}:{:02}:{:02}.{:03}",
+        hours, minutes, seconds, milliseconds
+    )
 }
 
 /// Generate chapters from file list (one file = one chapter)
@@ -88,8 +96,7 @@ pub fn generate_chapters_from_files(
 
 /// Parse CUE file and extract chapters
 pub fn parse_cue_file(cue_path: &Path) -> Result<Vec<Chapter>> {
-    let content = std::fs::read_to_string(cue_path)
-        .context("Failed to read CUE file")?;
+    let content = std::fs::read_to_string(cue_path).context("Failed to read CUE file")?;
 
     let mut chapters = Vec::new();
     let mut current_chapter = 1u32;
@@ -158,17 +165,141 @@ pub fn write_mp4box_chapters(chapters: &[Chapter], output_path: &Path) -> Result
         content.push_str(&chapter.to_mp4box_format());
     }
 
-    std::fs::write(output_path, content)
-        .context("Failed to write chapter file")?;
+    std::fs::write(output_path, content).context("Failed to write chapter file")?;
 
     Ok(())
 }
 
+/// Build the chapter list for a (already analyzed) book folder.
+///
+/// This is the shared implementation used by both the `build` pipeline and the
+/// standalone `metadata export-chapters` command. `book_folder.tracks` must be
+/// populated (e.g. via `Analyzer::analyze_book_folder`) so that per-track
+/// durations are available.
+///
+/// * `chapter_source` is one of `auto` / `files` / `cue` / `none`. Unknown
+///   values fall back to `auto`.
+pub fn generate_chapters(book_folder: &BookFolder, chapter_source: &str) -> Result<Vec<Chapter>> {
+    match chapter_source {
+        "cue" => {
+            // Use CUE file if available
+            if let Some(ref cue_file) = book_folder.cue_file {
+                tracing::info!("Using CUE file for chapters: {}", cue_file.display());
+                return parse_cue_file(cue_file);
+            }
+            Ok(Vec::new())
+        }
+        "files" | "auto" => {
+            // Generate chapters from files
+            if book_folder.tracks.len() > 1 {
+                let files: Vec<&Path> = book_folder
+                    .tracks
+                    .iter()
+                    .map(|t| t.file_path.as_path())
+                    .collect();
+                let durations: Vec<f64> = book_folder
+                    .tracks
+                    .iter()
+                    .map(|t| t.quality.duration)
+                    .collect();
+
+                tracing::info!(
+                    "Generating {} chapters from files",
+                    book_folder.tracks.len()
+                );
+                Ok(generate_chapters_from_files(&files, &durations))
+            } else {
+                // Single file - check for CUE
+                if let Some(ref cue_file) = book_folder.cue_file {
+                    tracing::info!("Using CUE file for single-file book");
+                    parse_cue_file(cue_file)
+                } else {
+                    Ok(Vec::new())
+                }
+            }
+        }
+        "none" => Ok(Vec::new()),
+        _ => {
+            tracing::warn!("Unknown chapter source: {}, using auto", chapter_source);
+            generate_chapters(book_folder, "auto")
+        }
+    }
+}
+
+/// Sanitize a chapter title for safe inclusion in an ffmpeg metadata file.
+///
+/// ffmpeg's `;FFMETADATA1` format uses `=` as the key/value separator and is
+/// line-oriented, so embedded newlines and `=` signs are rewritten.
+fn sanitize_title(s: &str) -> String {
+    s.replace(['\r', '\n'], " ").replace('=', " - ")
+}
+
+/// Write chapters in ffmpeg's `;FFMETADATA1` chapter format.
+///
+/// Chapter end times are made contiguous with the next chapter's start (END =
+/// next START - 1) so ffmpeg does not warn about overlapping chapters. The last
+/// chapter keeps its full `end_time_ms`.
+pub fn write_ffmetadata(chapters: &[Chapter], path: &Path, timebase: &str) -> Result<()> {
+    if chapters.is_empty() {
+        anyhow::bail!("Cannot write ffmetadata: no chapters provided");
+    }
+
+    let mut f = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create chapter file: {}", path.display()))?;
+
+    writeln!(f, ";FFMETADATA1").context("Failed to write ffmetadata header")?;
+
+    for (i, c) in chapters.iter().enumerate() {
+        let end = if i + 1 < chapters.len() {
+            chapters[i + 1].start_time_ms.saturating_sub(1)
+        } else {
+            c.end_time_ms
+        };
+
+        writeln!(f, "[CHAPTER]").context("Failed to write chapter block")?;
+        writeln!(f, "TIMEBASE={timebase}").context("Failed to write timebase")?;
+        writeln!(f, "START={}", c.start_time_ms).context("Failed to write start")?;
+        writeln!(f, "END={end}").context("Failed to write end")?;
+        writeln!(f, "title={}", sanitize_title(&c.title)).context("Failed to write title")?;
+        writeln!(f).context("Failed to write chapter separator")?;
+    }
+
+    Ok(())
+}
+
+/// Write chapters as pretty-printed JSON (for downstream programmatic use).
+pub fn write_json(chapters: &[Chapter], path: &Path) -> Result<()> {
+    let v: Vec<serde_json::Value> = chapters
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "number": c.number,
+                "title": c.title,
+                "start_time_ms": c.start_time_ms,
+                "end_time_ms": c.end_time_ms,
+            })
+        })
+        .collect();
+
+    std::fs::write(path, serde_json::to_string_pretty(&v)?)
+        .with_context(|| format!("Failed to write JSON chapters: {}", path.display()))?;
+
+    Ok(())
+}
+
+/// Derive a default output path for `export-chapters` when `--output` is omitted.
+///
+/// Places `<book_name>.chapters.txt` next to the book's folder.
+pub fn default_chapters_output(folder_path: &Path) -> PathBuf {
+    let name = folder_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("audiobook");
+    folder_path.join(format!("{}.chapters.txt", name))
+}
+
 /// Inject chapters into M4B file using MP4Box
-pub async fn inject_chapters_mp4box(
-    m4b_file: &Path,
-    chapters_file: &Path,
-) -> Result<()> {
+pub async fn inject_chapters_mp4box(m4b_file: &Path, chapters_file: &Path) -> Result<()> {
     let output = tokio::process::Command::new("MP4Box")
         .args(&["-chap", &chapters_file.display().to_string()])
         .arg(m4b_file)
@@ -188,6 +319,7 @@ pub async fn inject_chapters_mp4box(
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use tempfile::tempdir;
 
     #[test]
     fn test_format_time_ms() {
@@ -230,5 +362,82 @@ mod tests {
 
         assert!(formatted.contains("CHAPTER1=00:00:00.000"));
         assert!(formatted.contains("CHAPTER1NAME=Test Chapter"));
+    }
+
+    #[test]
+    fn test_sanitize_title() {
+        assert_eq!(sanitize_title("A=B"), "A - B");
+        assert_eq!(sanitize_title("A = B"), "A  -  B");
+        assert_eq!(sanitize_title("line1\nline2"), "line1 line2");
+        assert_eq!(sanitize_title("cr\r"), "cr ");
+        assert_eq!(sanitize_title("normal title"), "normal title");
+    }
+
+    #[test]
+    fn test_write_ffmetadata() {
+        let chapters = vec![
+            Chapter::new(1, "Intro".to_string(), 0, 4480000),
+            Chapter::new(2, "The Journey".to_string(), 4480000, 38839999),
+        ];
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("chapters.txt");
+
+        write_ffmetadata(&chapters, &path, "1/1000").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.starts_with(";FFMETADATA1"));
+        assert!(content.contains("TIMEBASE=1/1000"));
+        assert!(content.contains("START=0"));
+        // END must be contiguous with the next start (next START - 1)
+        assert!(content.contains("END=4479999"));
+        assert!(content.contains("START=4480000"));
+        assert!(content.contains("END=38839999"));
+        assert!(content.contains("title=Intro"));
+        assert!(content.contains("title=The Journey"));
+        assert_eq!(content.matches("[CHAPTER]").count(), 2);
+    }
+
+    #[test]
+    fn test_write_ffmetadata_sanitizes_titles() {
+        let chapters = vec![Chapter::new(1, "A = B\nnewline".to_string(), 0, 1000)];
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.txt");
+
+        write_ffmetadata(&chapters, &path, "1/1000").unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+
+        assert!(content.contains("title=A  -  B newline"));
+        // No stray newline inside the title line
+        assert!(!content.contains("title=A  -  B\n"));
+    }
+
+    #[test]
+    fn test_write_ffmetadata_empty_errors() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("empty.txt");
+        let result = write_ffmetadata(&[], &path, "1/1000");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_generate_chapters_from_book_folder() {
+        use crate::models::{BookFolder, QualityProfile, Track};
+
+        let mut book = BookFolder::new(PathBuf::from("/tmp/My Book"));
+        let q1 = QualityProfile::new(128, 44100, 2, "mp3".to_string(), 120.5).unwrap();
+        let q2 = QualityProfile::new(128, 44100, 2, "mp3".to_string(), 180.3).unwrap();
+        let q3 = QualityProfile::new(128, 44100, 2, "mp3".to_string(), 95.7).unwrap();
+        book.tracks = vec![
+            Track::new(PathBuf::from("/tmp/My Book/01 First.mp3"), q1),
+            Track::new(PathBuf::from("/tmp/My Book/02 Second.mp3"), q2),
+            Track::new(PathBuf::from("/tmp/My Book/03 Third.mp3"), q3),
+        ];
+
+        let chapters = generate_chapters(&book, "auto").unwrap();
+        assert_eq!(chapters.len(), 3);
+        assert_eq!(chapters[0].start_time_ms, 0);
+        assert_eq!(chapters[1].start_time_ms, 120500);
+        assert_eq!(chapters[2].start_time_ms, 300800); // 120.5 + 180.3 = 300.8s
+        assert_eq!(chapters[0].title, "01 First");
     }
 }

--- a/src/audio/encoder.rs
+++ b/src/audio/encoder.rs
@@ -134,7 +134,10 @@ mod tests {
 
     #[test]
     fn test_encoder_from_str() {
-        assert_eq!(AacEncoder::from_str("aac_at"), Some(AacEncoder::AppleSilicon));
+        assert_eq!(
+            AacEncoder::from_str("aac_at"),
+            Some(AacEncoder::AppleSilicon)
+        );
         assert_eq!(AacEncoder::from_str("libfdk_aac"), Some(AacEncoder::LibFdk));
         assert_eq!(AacEncoder::from_str("libfdk"), Some(AacEncoder::LibFdk));
         assert_eq!(AacEncoder::from_str("aac"), Some(AacEncoder::Native));

--- a/src/audio/ffmpeg.rs
+++ b/src/audio/ffmpeg.rs
@@ -61,8 +61,10 @@ impl FFmpeg {
     pub async fn probe_audio_file(&self, path: &Path) -> Result<QualityProfile> {
         let output = Command::new(&self.ffprobe_path)
             .args(&[
-                "-v", "quiet",
-                "-print_format", "json",
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
                 "-show_streams",
                 "-show_format",
             ])
@@ -104,7 +106,8 @@ impl FFmpeg {
             json["format"]["bit_rate"]
                 .as_str()
                 .context("No bitrate found")?
-                .parse::<u32>()? / 1000
+                .parse::<u32>()?
+                / 1000
         };
 
         // Extract sample rate
@@ -148,13 +151,8 @@ impl FFmpeg {
     ) -> Result<()> {
         let mut cmd = Command::new(&self.ffmpeg_path);
 
-        cmd.args(&[
-            "-y",
-            "-f", "concat",
-            "-safe", "0",
-            "-i",
-        ])
-        .arg(concat_file);
+        cmd.args(&["-y", "-f", "concat", "-safe", "0", "-i"])
+            .arg(concat_file);
 
         // Skip video streams (embedded cover art in MP3s)
         cmd.arg("-vn");
@@ -165,10 +163,14 @@ impl FFmpeg {
         } else {
             // Transcode mode
             cmd.args(&[
-                "-c:a", encoder.name(),
-                "-b:a", &format!("{}k", quality.bitrate),
-                "-ar", &quality.sample_rate.to_string(),
-                "-ac", &quality.channels.to_string(),
+                "-c:a",
+                encoder.name(),
+                "-b:a",
+                &format!("{}k", quality.bitrate),
+                "-ar",
+                &quality.sample_rate.to_string(),
+                "-ac",
+                &quality.channels.to_string(),
             ]);
 
             // Use multiple threads for encoding if encoder supports it
@@ -224,8 +226,7 @@ impl FFmpeg {
     ) -> Result<()> {
         let mut cmd = Command::new(&self.ffmpeg_path);
 
-        cmd.args(&["-y", "-i"])
-            .arg(input_file);
+        cmd.args(&["-y", "-i"]).arg(input_file);
 
         // Skip video streams (embedded cover art in MP3s)
         cmd.arg("-vn");
@@ -234,10 +235,14 @@ impl FFmpeg {
             cmd.args(&["-c", "copy"]);
         } else {
             cmd.args(&[
-                "-c:a", encoder.name(),
-                "-b:a", &format!("{}k", quality.bitrate),
-                "-ar", &quality.sample_rate.to_string(),
-                "-ac", &quality.channels.to_string(),
+                "-c:a",
+                encoder.name(),
+                "-b:a",
+                &format!("{}k", quality.bitrate),
+                "-ar",
+                &quality.sample_rate.to_string(),
+                "-ac",
+                &quality.channels.to_string(),
             ]);
 
             // Use multiple threads for encoding if encoder supports it
@@ -292,7 +297,8 @@ impl FFmpeg {
             }
 
             // Get absolute path for better compatibility
-            let abs_path = file.canonicalize()
+            let abs_path = file
+                .canonicalize()
                 .with_context(|| format!("Failed to resolve path: {}", file.display()))?;
 
             // Escape the path for FFmpeg concat format
@@ -306,38 +312,30 @@ impl FFmpeg {
             content.push_str(&format!("file '{}'\n", escaped));
         }
 
-        std::fs::write(output, content)
-            .context("Failed to write concat file")?;
+        std::fs::write(output, content).context("Failed to write concat file")?;
 
         Ok(())
     }
 
     /// Concatenate M4B files losslessly (copy mode only)
-    pub async fn concat_m4b_files(
-        &self,
-        concat_file: &Path,
-        output_file: &Path,
-    ) -> Result<()> {
+    pub async fn concat_m4b_files(&self, concat_file: &Path, output_file: &Path) -> Result<()> {
         let mut cmd = Command::new(&self.ffmpeg_path);
 
-        cmd.args([
-            "-y",
-            "-f", "concat",
-            "-safe", "0",
-            "-i",
-        ])
-        .arg(concat_file)
-        .args([
-            // Drop video streams. Source M4B files may embed cover art as an
-            // mjpeg video stream; the ipod/M4B muxer rejects mjpeg in copy mode
-            // ("Could not find tag for codec mjpeg"), so carrying it breaks the
-            // mux (issue #17). Cover art is re-injected downstream via
-            // AtomicParsley from the scanner's extracted/standalone cover file.
-            "-vn",
-            "-c", "copy",           // Lossless copy
-            "-movflags", "+faststart",
-        ])
-        .arg(output_file);
+        cmd.args(["-y", "-f", "concat", "-safe", "0", "-i"])
+            .arg(concat_file)
+            .args([
+                // Drop video streams. Source M4B files may embed cover art as an
+                // mjpeg video stream; the ipod/M4B muxer rejects mjpeg in copy mode
+                // ("Could not find tag for codec mjpeg"), so carrying it breaks the
+                // mux (issue #17). Cover art is re-injected downstream via
+                // AtomicParsley from the scanner's extracted/standalone cover file.
+                "-vn",
+                "-c",
+                "copy", // Lossless copy
+                "-movflags",
+                "+faststart",
+            ])
+            .arg(output_file);
 
         tracing::debug!("FFmpeg M4B concat command: {:?}", cmd.as_std());
         tracing::info!("Concatenating M4B files (lossless copy mode)");
@@ -360,11 +358,7 @@ impl FFmpeg {
     /// Probe metadata from audio file
     pub async fn probe_metadata(&self, path: &Path) -> Result<AudioMetadata> {
         let output = Command::new(&self.ffprobe_path)
-            .args([
-                "-v", "quiet",
-                "-print_format", "json",
-                "-show_format",
-            ])
+            .args(["-v", "quiet", "-print_format", "json", "-show_format"])
             .arg(path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -387,7 +381,9 @@ impl FFmpeg {
             artist: tags["artist"].as_str().map(String::from),
             album: tags["album"].as_str().map(String::from),
             album_artist: tags["album_artist"].as_str().map(String::from),
-            year: tags["date"].as_str().and_then(|s| s.get(..4).and_then(|y| y.parse().ok())),
+            year: tags["date"]
+                .as_str()
+                .and_then(|s| s.get(..4).and_then(|y| y.parse().ok())),
             genre: tags["genre"].as_str().map(String::from),
             composer: tags["composer"].as_str().map(String::from),
             comment: tags["comment"].as_str().map(String::from),
@@ -401,11 +397,7 @@ impl FFmpeg {
     /// (issue #15). A single ffprobe invocation reads both from `format`.
     pub async fn probe_duration_and_title(&self, path: &Path) -> Result<(u64, Option<String>)> {
         let output = Command::new(&self.ffprobe_path)
-            .args([
-                "-v", "quiet",
-                "-print_format", "json",
-                "-show_format",
-            ])
+            .args(["-v", "quiet", "-print_format", "json", "-show_format"])
             .arg(path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/src/audio/metadata.rs
+++ b/src/audio/metadata.rs
@@ -179,7 +179,7 @@ pub fn extract_embedded_cover(file_path: &Path, output_path: &Path) -> Result<bo
         .unwrap_or("");
 
     match extension.to_lowercase().as_str() {
-        "mp3" => extract_mp3_cover_art(file_path, output_path),
+        "mp3" | "wma" => extract_mp3_cover_art(file_path, output_path),
         "m4a" | "m4b" => extract_m4a_cover_art(file_path, output_path),
         _ => {
             tracing::debug!("Unsupported format for cover extraction: {}", extension);

--- a/src/audio/metadata.rs
+++ b/src/audio/metadata.rs
@@ -1,14 +1,13 @@
 //! Audio metadata extraction and manipulation
 
-use crate::models::{Track, AudibleMetadata};
+use crate::models::{AudibleMetadata, Track};
 use anyhow::{Context, Result};
 use id3::TagLike;
 use std::path::Path;
 
 /// Extract metadata from MP3 file using ID3 tags
 pub fn extract_mp3_metadata(track: &mut Track) -> Result<()> {
-    let tag = id3::Tag::read_from_path(&track.file_path)
-        .context("Failed to read ID3 tags")?;
+    let tag = id3::Tag::read_from_path(&track.file_path).context("Failed to read ID3 tags")?;
 
     // Extract basic metadata
     track.title = tag.title().map(|s| s.to_string());
@@ -18,7 +17,10 @@ pub fn extract_mp3_metadata(track: &mut Track) -> Result<()> {
     track.genre = tag.genre().map(|s| s.to_string());
     track.year = tag.year().map(|y| y as u32);
     track.comment = tag.comments().next().map(|c| c.text.clone());
-    track.composer = tag.get("TCOM").and_then(|frame| frame.content().text()).map(|s| s.to_string());
+    track.composer = tag
+        .get("TCOM")
+        .and_then(|frame| frame.content().text())
+        .map(|s| s.to_string());
 
     // Extract track number
     track.track_number = tag.track();
@@ -28,8 +30,8 @@ pub fn extract_mp3_metadata(track: &mut Track) -> Result<()> {
 
 /// Extract metadata from M4A/M4B file
 pub fn extract_m4a_metadata(track: &mut Track) -> Result<()> {
-    let tag = mp4ameta::Tag::read_from_path(&track.file_path)
-        .context("Failed to read M4A metadata")?;
+    let tag =
+        mp4ameta::Tag::read_from_path(&track.file_path).context("Failed to read M4A metadata")?;
 
     // Extract basic metadata
     track.title = tag.title().map(|s| s.to_string());
@@ -60,11 +62,7 @@ pub async fn extract_flac_metadata(track: &mut Track) -> Result<()> {
     // when called from the parallel analysis pipeline, matching every other
     // ffprobe/ffmpeg call site in the codebase.
     let output = tokio::process::Command::new("ffprobe")
-        .args([
-            "-v", "quiet",
-            "-print_format", "json",
-            "-show_format",
-        ])
+        .args(["-v", "quiet", "-print_format", "json", "-show_format"])
         .arg(&track.file_path)
         .output()
         .await
@@ -74,8 +72,8 @@ pub async fn extract_flac_metadata(track: &mut Track) -> Result<()> {
         anyhow::bail!("ffprobe failed to read FLAC metadata");
     }
 
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
-        .context("Failed to parse ffprobe JSON output")?;
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("Failed to parse ffprobe JSON output")?;
 
     // Vorbis comment keys can be any case; collect them lowercased for lookup.
     let tags: std::collections::HashMap<String, String> = json["format"]["tags"]
@@ -104,9 +102,11 @@ pub async fn extract_flac_metadata(track: &mut Track) -> Result<()> {
     track.composer = get("composer");
 
     // TRACKNUMBER may be "5" or "5/12"; take the part before the slash.
-    track.track_number = get("tracknumber")
-        .or_else(|| get("track"))
-        .and_then(|s| s.split('/').next().and_then(|n| n.trim().parse::<u32>().ok()));
+    track.track_number = get("tracknumber").or_else(|| get("track")).and_then(|s| {
+        s.split('/')
+            .next()
+            .and_then(|n| n.trim().parse::<u32>().ok())
+    });
 
     Ok(())
 }
@@ -127,8 +127,7 @@ pub async fn extract_metadata(track: &mut Track) -> Result<()> {
 
 /// Extract embedded cover art from MP3 file (APIC frame)
 pub fn extract_mp3_cover_art(file_path: &Path, output_path: &Path) -> Result<bool> {
-    let tag = id3::Tag::read_from_path(file_path)
-        .context("Failed to read ID3 tag")?;
+    let tag = id3::Tag::read_from_path(file_path).context("Failed to read ID3 tag")?;
 
     // Collect pictures to avoid borrow checker issues
     let pictures: Vec<_> = tag.pictures().collect();
@@ -142,8 +141,7 @@ pub fn extract_mp3_cover_art(file_path: &Path, output_path: &Path) -> Result<boo
             picture.picture_type
         );
 
-        std::fs::write(output_path, &picture.data)
-            .context("Failed to write extracted cover")?;
+        std::fs::write(output_path, &picture.data).context("Failed to write extracted cover")?;
 
         Ok(true)
     } else {
@@ -154,8 +152,7 @@ pub fn extract_mp3_cover_art(file_path: &Path, output_path: &Path) -> Result<boo
 
 /// Extract embedded cover art from M4A/M4B file
 pub fn extract_m4a_cover_art(file_path: &Path, output_path: &Path) -> Result<bool> {
-    let tag = mp4ameta::Tag::read_from_path(file_path)
-        .context("Failed to read M4A tag")?;
+    let tag = mp4ameta::Tag::read_from_path(file_path).context("Failed to read M4A tag")?;
 
     // Get artwork (first image)
     if let Some(artwork) = tag.artwork() {
@@ -165,8 +162,7 @@ pub fn extract_m4a_cover_art(file_path: &Path, output_path: &Path) -> Result<boo
             artwork.data.len()
         );
 
-        std::fs::write(output_path, &artwork.data)
-            .context("Failed to write extracted cover")?;
+        std::fs::write(output_path, &artwork.data).context("Failed to write extracted cover")?;
 
         Ok(true)
     } else {
@@ -322,7 +318,12 @@ pub async fn inject_audible_metadata(
 
     // Publisher
     if let Some(publisher) = &audible.publisher {
-        cmd.args(&["--rDNSatom", &format!("{}", publisher), "name=publisher", "domain=com.apple.iTunes"]);
+        cmd.args(&[
+            "--rDNSatom",
+            &format!("{}", publisher),
+            "name=publisher",
+            "domain=com.apple.iTunes",
+        ]);
     }
 
     // Year
@@ -336,7 +337,12 @@ pub async fn inject_audible_metadata(
     }
 
     // ASIN as custom atom (for Audiobookshelf)
-    cmd.args(&["--rDNSatom", &audible.asin, "name=asin", "domain=com.audible"]);
+    cmd.args(&[
+        "--rDNSatom",
+        &audible.asin,
+        "name=asin",
+        "domain=com.audible",
+    ]);
 
     // Cover art (strips existing artwork first — issue #11)
     cmd.args(artwork_args(cover_art));

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -7,16 +7,26 @@
 //! - Audible: Audible metadata fetching and integration
 //! - Encoder: AAC encoder detection and selection
 
+pub mod audible;
+mod chapter_import;
+mod chapters;
+pub mod encoder;
 mod ffmpeg;
 mod metadata;
-mod chapters;
-pub mod audible;
-pub mod encoder;
-mod chapter_import;
 
-pub use ffmpeg::{FFmpeg, AudioMetadata};
-pub use metadata::{extract_metadata, extract_mp3_metadata, extract_m4a_metadata, extract_flac_metadata, inject_metadata_atomicparsley, inject_audible_metadata, extract_embedded_cover};
-pub use chapters::{Chapter, generate_chapters_from_files, parse_cue_file, write_mp4box_chapters, inject_chapters_mp4box};
-pub use audible::{AudibleClient, detect_asin, clean_sequence};
-pub use encoder::{AacEncoder, get_encoder, EncoderDetector};
-pub use chapter_import::{ChapterSource, ChapterMergeStrategy, ChapterComparison, parse_text_chapters, parse_epub_chapters, merge_chapters, merge_chapter_lists, read_m4b_chapters};
+pub use audible::{clean_sequence, detect_asin, AudibleClient};
+pub use chapter_import::{
+    merge_chapter_lists, merge_chapters, parse_epub_chapters, parse_text_chapters,
+    read_m4b_chapters, ChapterComparison, ChapterMergeStrategy, ChapterSource,
+};
+pub use chapters::{
+    default_chapters_output, generate_chapters, generate_chapters_from_files,
+    inject_chapters_mp4box, parse_cue_file, write_ffmetadata, write_json, write_mp4box_chapters,
+    Chapter,
+};
+pub use encoder::{get_encoder, AacEncoder, EncoderDetector};
+pub use ffmpeg::{AudioMetadata, FFmpeg};
+pub use metadata::{
+    extract_embedded_cover, extract_flac_metadata, extract_m4a_metadata, extract_metadata,
+    extract_mp3_metadata, inject_audible_metadata, inject_metadata_atomicparsley,
+};

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,6 +1,6 @@
 //! CLI commands and arguments
 
-use clap::{Parser, Subcommand, Args};
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
 use crate::VERSION;
@@ -247,6 +247,45 @@ pub enum MetadataCommands {
         #[arg(long, default_value = "interactive")]
         merge_strategy: String,
     },
+
+    /// Export chapter metadata to a file (no transcoding/injection)
+    ///
+    /// Scans a source audiobook directory (same semantics as `build --root`),
+    /// derives chapter timestamps from track durations and filenames, and writes
+    /// an ffmpeg-style `;FFMETADATA1` chapter file. This bypasses AtomicParsley/
+    /// MP4Box, so it is usable even when those tools crash during `build`.
+    /// The resulting file can be injected with:
+    ///   ffmpeg -i book.m4b -i chapters.txt -map_metadata 0 -map_chapters 1 -codec copy out.m4b
+    ExportChapters(ExportChaptersArgs),
+}
+
+/// Arguments for the `metadata export-chapters` subcommand
+#[derive(Args)]
+pub struct ExportChaptersArgs {
+    /// Source audiobook directory (scanned like `build --root`)
+    #[arg(short, long)]
+    pub root: PathBuf,
+
+    /// Output file; defaults to <root>/<book_name>.chapters.txt
+    #[arg(long, short = 'o', value_name = "FILE")]
+    pub output: Option<PathBuf>,
+
+    /// Chapter title source: auto / files / cue / none
+    #[arg(long, default_value = "auto")]
+    pub chapter_source: String,
+
+    /// Timebase for the ffmpeg metadata file (default 1/1000 = milliseconds)
+    #[arg(long, default_value = "1/1000")]
+    pub timebase: String,
+
+    /// Also write a JSON version of the chapters alongside the text file
+    #[arg(long)]
+    pub json: bool,
+
+    /// Treat `root` as an existing M4B file and export its already-embedded
+    /// chapters (useful when only the M4B is available)
+    #[arg(long)]
+    pub from_m4b: bool,
 }
 
 /// Arguments for the match command

--- a/src/cli/handlers.rs
+++ b/src/cli/handlers.rs
@@ -1,12 +1,12 @@
 //! CLI command handlers
 
-use crate::cli::commands::{BuildArgs, ConfigCommands, OrganizeArgs, MetadataCommands, MatchArgs};
+use crate::audio::{detect_asin, AacEncoder, AudibleClient};
+use crate::cli::commands::{BuildArgs, ConfigCommands, MatchArgs, MetadataCommands, OrganizeArgs};
 use crate::core::{Analyzer, BatchProcessor, M4bMerger, Organizer, RetryConfig, Scanner};
-use crate::models::{BookCase, Config, AudibleRegion, CurrentMetadata, MetadataSource};
-use crate::utils::{ConfigManager, DependencyChecker, AudibleCache, scoring, extraction};
-use crate::audio::{AacEncoder, AudibleClient, detect_asin};
-use crate::ui::{prompt_match_selection, prompt_manual_metadata, prompt_custom_search, UserChoice};
-use anyhow::{Context, Result, bail};
+use crate::models::{AudibleRegion, BookCase, Config, CurrentMetadata, MetadataSource};
+use crate::ui::{prompt_custom_search, prompt_manual_metadata, prompt_match_selection, UserChoice};
+use crate::utils::{extraction, scoring, AudibleCache, ConfigManager, DependencyChecker};
+use anyhow::{bail, Context, Result};
 use console::style;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -19,7 +19,10 @@ fn resolve_encoder(config: &Config, cli_override: Option<&str>) -> AacEncoder {
             tracing::info!("Using encoder from CLI argument: {}", encoder.name());
             return encoder;
         } else {
-            tracing::warn!("Unknown encoder '{}', falling back to auto-detection", encoder_str);
+            tracing::warn!(
+                "Unknown encoder '{}', falling back to auto-detection",
+                encoder_str
+            );
         }
     }
 
@@ -60,8 +63,7 @@ fn resolve_encoder(config: &Config, cli_override: Option<&str>) -> AacEncoder {
 
 /// Try to detect if current directory is an audiobook folder
 fn try_detect_current_as_audiobook() -> Result<Option<PathBuf>> {
-    let current_dir = std::env::current_dir()
-        .context("Failed to get current directory")?;
+    let current_dir = std::env::current_dir().context("Failed to get current directory")?;
 
     // Safety check: Don't auto-detect from filesystem root
     if current_dir.parent().is_none() {
@@ -69,8 +71,7 @@ fn try_detect_current_as_audiobook() -> Result<Option<PathBuf>> {
     }
 
     // Check for MP3 files in current directory
-    let entries = std::fs::read_dir(&current_dir)
-        .context("Failed to read current directory")?;
+    let entries = std::fs::read_dir(&current_dir).context("Failed to read current directory")?;
 
     let mp3_count = entries
         .filter_map(|e| e.ok())
@@ -97,8 +98,7 @@ fn is_audiobook_folder(path: &std::path::Path) -> Result<bool> {
         return Ok(false);
     }
 
-    let entries = std::fs::read_dir(path)
-        .context("Failed to read directory")?;
+    let entries = std::fs::read_dir(path).context("Failed to read directory")?;
 
     let audio_count = entries
         .filter_map(|e| e.ok())
@@ -107,9 +107,9 @@ fn is_audiobook_folder(path: &std::path::Path) -> Result<bool> {
                 .extension()
                 .and_then(|ext| ext.to_str())
                 .map(|ext| {
-                    ext.eq_ignore_ascii_case("mp3") ||
-                    ext.eq_ignore_ascii_case("m4a") ||
-                    ext.eq_ignore_ascii_case("m4b")
+                    ext.eq_ignore_ascii_case("mp3")
+                        || ext.eq_ignore_ascii_case("m4a")
+                        || ext.eq_ignore_ascii_case("m4b")
                 })
                 .unwrap_or(false)
         })
@@ -121,7 +121,9 @@ fn is_audiobook_folder(path: &std::path::Path) -> Result<bool> {
 /// Handle the build command
 pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
     // Determine root directory (CLI arg > config > auto-detect > error)
-    let (root, auto_detected) = if let Some(root_path) = args.root.or(config.directories.source.clone()) {
+    let (root, auto_detected) = if let Some(root_path) =
+        args.root.or(config.directories.source.clone())
+    {
         // Check if root itself is an audiobook folder
         if is_audiobook_folder(&root_path)? {
             println!(
@@ -197,10 +199,7 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
     if args.merge_m4b {
         for book in &mut book_folders {
             if book.m4b_files.len() > 1 && book.case == BookCase::C {
-                tracing::info!(
-                    "Forcing merge for {} (--merge-m4b flag)",
-                    book.name
-                );
+                tracing::info!("Forcing merge for {} (--merge-m4b flag)", book.name);
                 book.case = BookCase::E;
             }
         }
@@ -216,7 +215,10 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
 
     // Dry run mode
     if args.dry_run {
-        println!("\n{} DRY RUN MODE - No changes will be made\n", style("ℹ").blue());
+        println!(
+            "\n{} DRY RUN MODE - No changes will be made\n",
+            style("ℹ").blue()
+        );
         for book in &book_folders {
             println!(
                 "  {} {} ({} files, {:.1} min)",
@@ -247,7 +249,8 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
     if args.fetch_audible || config.metadata.audible.enabled {
         println!("\n{} Fetching Audible metadata...", style("→").cyan());
 
-        let audible_region = args.audible_region
+        let audible_region = args
+            .audible_region
             .as_deref()
             .or(Some(&config.metadata.audible.region))
             .and_then(|r| AudibleRegion::from_str(r).ok())
@@ -276,7 +279,12 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
                 match cache.get(&asin).await {
                     Some(cached) => {
                         book.audible_metadata = Some(cached);
-                        println!("  {} {} (ASIN: {}, cached)", style("✓").green(), book.name, asin);
+                        println!(
+                            "  {} {} (ASIN: {}, cached)",
+                            style("✓").green(),
+                            book.name,
+                            asin
+                        );
                     }
                     None => {
                         // Fetch from API
@@ -291,16 +299,28 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
                                 if config.metadata.audible.fetch_chapters {
                                     match client.fetch_chapters(&asin).await {
                                         Ok(chapters) => {
-                                            tracing::debug!("Fetched {} chapters for ASIN: {}", chapters.len(), asin);
+                                            tracing::debug!(
+                                                "Fetched {} chapters for ASIN: {}",
+                                                chapters.len(),
+                                                asin
+                                            );
                                         }
                                         Err(e) => {
-                                            tracing::debug!("No chapters available for ASIN {}: {:?}", asin, e);
+                                            tracing::debug!(
+                                                "No chapters available for ASIN {}: {:?}",
+                                                asin,
+                                                e
+                                            );
                                         }
                                     }
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!("Failed to fetch metadata for {}: {:?}", book.name, e);
+                                tracing::warn!(
+                                    "Failed to fetch metadata for {}: {:?}",
+                                    book.name,
+                                    e
+                                );
                                 println!("  {} {} - fetch failed", style("⚠").yellow(), book.name);
                             }
                         }
@@ -320,7 +340,12 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
                         match cache.get(asin).await {
                             Some(cached) => {
                                 book.audible_metadata = Some(cached);
-                                println!("  {} {} (matched: {}, cached)", style("✓").green(), book.name, asin);
+                                println!(
+                                    "  {} {} (matched: {}, cached)",
+                                    style("✓").green(),
+                                    book.name,
+                                    asin
+                                );
                             }
                             None => {
                                 // Fetch from API
@@ -329,23 +354,44 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
                                         // Cache the result
                                         let _ = cache.set(asin, &metadata).await;
                                         book.audible_metadata = Some(metadata);
-                                        println!("  {} {} (matched: {})", style("✓").green(), book.name, asin);
+                                        println!(
+                                            "  {} {} (matched: {})",
+                                            style("✓").green(),
+                                            book.name,
+                                            asin
+                                        );
 
                                         // Fetch chapters if enabled
                                         if config.metadata.audible.fetch_chapters {
                                             match client.fetch_chapters(asin).await {
                                                 Ok(chapters) => {
-                                                    tracing::debug!("Fetched {} chapters for ASIN: {}", chapters.len(), asin);
+                                                    tracing::debug!(
+                                                        "Fetched {} chapters for ASIN: {}",
+                                                        chapters.len(),
+                                                        asin
+                                                    );
                                                 }
                                                 Err(e) => {
-                                                    tracing::debug!("No chapters available for ASIN {}: {:?}", asin, e);
+                                                    tracing::debug!(
+                                                        "No chapters available for ASIN {}: {:?}",
+                                                        asin,
+                                                        e
+                                                    );
                                                 }
                                             }
                                         }
                                     }
                                     Err(e) => {
-                                        tracing::warn!("Failed to fetch metadata after match for {}: {:?}", book.name, e);
-                                        println!("  {} {} - fetch failed", style("⚠").yellow(), book.name);
+                                        tracing::warn!(
+                                            "Failed to fetch metadata after match for {}: {:?}",
+                                            book.name,
+                                            e
+                                        );
+                                        println!(
+                                            "  {} {} - fetch failed",
+                                            style("⚠").yellow(),
+                                            book.name
+                                        );
                                     }
                                 }
                             }
@@ -361,7 +407,10 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
                     }
                 }
             } else {
-                tracing::debug!("No ASIN detected and auto-match disabled for: {}", book.name);
+                tracing::debug!(
+                    "No ASIN detected and auto-match disabled for: {}",
+                    book.name
+                );
             }
 
             // Download the Audible cover so `build --fetch-audible` embeds cover
@@ -395,8 +444,12 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
             }
         }
 
-        let fetched_count = book_folders.iter().filter(|b| b.audible_metadata.is_some()).count();
-        println!("{} Fetched metadata for {}/{} books",
+        let fetched_count = book_folders
+            .iter()
+            .filter(|b| b.audible_metadata.is_some())
+            .count();
+        println!(
+            "{} Fetched metadata for {}/{} books",
             style("✓").green(),
             style(fetched_count).cyan(),
             book_folders.len()
@@ -409,13 +462,15 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
         args.out.unwrap_or(root.clone())
     } else {
         // Normal mode: respect config
-        args.out.or_else(|| {
-            if config.directories.output == "same_as_source" {
-                Some(root.clone())
-            } else {
-                Some(PathBuf::from(&config.directories.output))
-            }
-        }).context("No output directory specified")?
+        args.out
+            .or_else(|| {
+                if config.directories.output == "same_as_source" {
+                    Some(root.clone())
+                } else {
+                    Some(PathBuf::from(&config.directories.output))
+                }
+            })
+            .context("No output directory specified")?
     };
 
     // Create batch processor with config settings
@@ -429,7 +484,9 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
     let max_concurrent = if config.performance.max_concurrent_encodes == "auto" {
         num_cpus::get() // Use all CPU cores
     } else {
-        config.performance.max_concurrent_encodes
+        config
+            .performance
+            .max_concurrent_encodes
             .parse::<usize>()
             .unwrap_or(num_cpus::get())
             .clamp(1, 16)
@@ -439,7 +496,9 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
     let max_concurrent_files = if config.performance.max_concurrent_files_per_book == "auto" {
         num_cpus::get()
     } else {
-        config.performance.max_concurrent_files_per_book
+        config
+            .performance
+            .max_concurrent_files_per_book
             .parse::<usize>()
             .unwrap_or(8)
             .clamp(1, 32)
@@ -489,11 +548,7 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
 
             match merger.merge_m4b_files(&book, &output_dir).await {
                 Ok(output_path) => {
-                    println!(
-                        "  {} Merged: {}",
-                        style("✓").green(),
-                        output_path.display()
-                    );
+                    println!("  {} Merged: {}", style("✓").green(), output_path.display());
                 }
                 Err(e) => {
                     // Use the alternate formatter so the full anyhow context chain
@@ -515,15 +570,15 @@ pub async fn handle_build(args: BuildArgs, config: Config) -> Result<()> {
 
     // Process batch (regular conversions)
     if !book_folders.is_empty() {
-        println!("\n{} Processing {} audiobook(s)...\n", style("→").cyan(), book_folders.len());
+        println!(
+            "\n{} Processing {} audiobook(s)...\n",
+            style("→").cyan(),
+            book_folders.len()
+        );
     }
 
     let results = batch_processor
-        .process_batch(
-            book_folders,
-            &output_dir,
-            &config.quality.chapter_source,
-        )
+        .process_batch(book_folders, &output_dir, &config.quality.chapter_source)
         .await;
 
     // Print results
@@ -604,7 +659,10 @@ pub fn handle_organize(args: OrganizeArgs, config: Config) -> Result<()> {
 
     // Dry run notice
     if args.dry_run {
-        println!("\n{} DRY RUN MODE - No changes will be made\n", style("ℹ").blue());
+        println!(
+            "\n{} DRY RUN MODE - No changes will be made\n",
+            style("ℹ").blue()
+        );
     }
 
     // Organize books
@@ -648,7 +706,10 @@ pub fn handle_organize(args: OrganizeArgs, config: Config) -> Result<()> {
         .iter()
         .filter(|r| r.success && r.destination_path.is_some())
         .count();
-    let skipped = results.iter().filter(|r| r.destination_path.is_none()).count();
+    let skipped = results
+        .iter()
+        .filter(|r| r.destination_path.is_none())
+        .count();
     let failed = results.iter().filter(|r| !r.success).count();
 
     println!(
@@ -711,17 +772,21 @@ pub fn handle_config(command: ConfigCommands) -> Result<()> {
         ConfigCommands::Validate { config: _ } => {
             let config_path = ConfigManager::default_config_path()?;
             ConfigManager::load(&config_path)?;
-            println!(
-                "{} Configuration is valid",
-                style("✓").green()
-            );
+            println!("{} Configuration is valid", style("✓").green());
         }
 
         ConfigCommands::Edit => {
             let config_path = ConfigManager::default_config_path()?;
-            println!("{} Opening editor for: {}", style("→").cyan(), style(config_path.display()).yellow());
+            println!(
+                "{} Opening editor for: {}",
+                style("→").cyan(),
+                style(config_path.display()).yellow()
+            );
             // TODO: Implement editor opening
-            println!("{} Editor integration not yet implemented", style("ℹ").blue());
+            println!(
+                "{} Editor integration not yet implemented",
+                style("ℹ").blue()
+            );
         }
     }
 
@@ -734,7 +799,10 @@ pub fn handle_check() -> Result<()> {
 
     let results = vec![
         ("FFmpeg", DependencyChecker::check_ffmpeg().found),
-        ("AtomicParsley", DependencyChecker::check_atomic_parsley().found),
+        (
+            "AtomicParsley",
+            DependencyChecker::check_atomic_parsley().found,
+        ),
         ("MP4Box", DependencyChecker::check_mp4box().found),
     ];
 
@@ -765,7 +833,11 @@ pub fn handle_check() -> Result<()> {
                 }
             }
         } else {
-            println!("  {} {} (not found)", style("✗").red(), style(tool).yellow());
+            println!(
+                "  {} {} (not found)",
+                style("✗").red(),
+                style(tool).yellow()
+            );
         }
     }
 
@@ -785,17 +857,22 @@ pub fn handle_check() -> Result<()> {
 /// Handle the metadata command
 pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Result<()> {
     match command {
-        MetadataCommands::Fetch { asin, title, author, region, output } => {
+        MetadataCommands::Fetch {
+            asin,
+            title,
+            author,
+            region,
+            output,
+        } => {
             println!("{} Fetching Audible metadata...", style("→").cyan());
 
             // Parse region
-            let audible_region = AudibleRegion::from_str(&region)
-                .unwrap_or(AudibleRegion::US);
+            let audible_region = AudibleRegion::from_str(&region).unwrap_or(AudibleRegion::US);
 
             // Create client and cache
             let client = AudibleClient::with_rate_limit(
                 audible_region,
-                config.metadata.audible.rate_limit_per_minute
+                config.metadata.audible.rate_limit_per_minute,
             )?;
             let cache = AudibleCache::with_ttl_hours(config.metadata.audible.cache_duration_hours)?;
 
@@ -815,8 +892,12 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
                 }
             } else if title.is_some() || author.is_some() {
                 // Search by title/author
-                println!("  {} Searching: title={:?}, author={:?}",
-                    style("→").cyan(), title, author);
+                println!(
+                    "  {} Searching: title={:?}, author={:?}",
+                    style("→").cyan(),
+                    title,
+                    author
+                );
 
                 let results = client.search(title.as_deref(), author.as_deref()).await?;
 
@@ -825,9 +906,14 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
                 }
 
                 // Display search results
-                println!("\n{} Found {} result(s):", style("✓").green(), results.len());
+                println!(
+                    "\n{} Found {} result(s):",
+                    style("✓").green(),
+                    results.len()
+                );
                 for (i, result) in results.iter().enumerate().take(5) {
-                    println!("  {}. {} by {}",
+                    println!(
+                        "  {}. {} by {}",
                         i + 1,
                         style(&result.title).yellow(),
                         style(result.authors_string()).cyan()
@@ -835,7 +921,10 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
                 }
 
                 // Fetch first result
-                println!("\n{} Fetching details for first result...", style("→").cyan());
+                println!(
+                    "\n{} Fetching details for first result...",
+                    style("→").cyan()
+                );
                 let asin_to_fetch = &results[0].asin;
 
                 if let Some(cached) = cache.get(asin_to_fetch).await {
@@ -856,10 +945,18 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
                 println!("{}: {}", style("Subtitle").bold(), subtitle);
             }
             if !metadata.authors.is_empty() {
-                println!("{}: {}", style("Author(s)").bold(), metadata.authors_string());
+                println!(
+                    "{}: {}",
+                    style("Author(s)").bold(),
+                    metadata.authors_string()
+                );
             }
             if !metadata.narrators.is_empty() {
-                println!("{}: {}", style("Narrator(s)").bold(), metadata.narrators_string());
+                println!(
+                    "{}: {}",
+                    style("Narrator(s)").bold(),
+                    metadata.narrators_string()
+                );
             }
             if let Some(publisher) = &metadata.publisher {
                 println!("{}: {}", style("Publisher").bold(), publisher);
@@ -895,7 +992,8 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
             if let Some(output_path) = output {
                 let json = serde_json::to_string_pretty(&metadata)?;
                 std::fs::write(&output_path, json)?;
-                println!("\n{} Saved metadata to: {}",
+                println!(
+                    "\n{} Saved metadata to: {}",
                     style("✓").green(),
                     style(output_path.display()).yellow()
                 );
@@ -914,7 +1012,10 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
             update_chapters_only,
             merge_strategy,
         } => {
-            use crate::audio::{read_m4b_chapters, parse_text_chapters, parse_epub_chapters, merge_chapters, inject_chapters_mp4box, write_mp4box_chapters, ChapterMergeStrategy};
+            use crate::audio::{
+                inject_chapters_mp4box, merge_chapters, parse_epub_chapters, parse_text_chapters,
+                read_m4b_chapters, write_mp4box_chapters, ChapterMergeStrategy,
+            };
             use std::str::FromStr;
 
             let action = if update_chapters_only {
@@ -939,9 +1040,16 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
 
             // Handle chapter update if requested
             let chapter_update_performed = if chapters.is_some() || chapters_asin.is_some() {
-                println!("  {} Reading existing chapters from M4B...", style("→").cyan());
+                println!(
+                    "  {} Reading existing chapters from M4B...",
+                    style("→").cyan()
+                );
                 let existing_chapters = read_m4b_chapters(&file).await?;
-                println!("  {} Found {} existing chapters", style("✓").green(), existing_chapters.len());
+                println!(
+                    "  {} Found {} existing chapters",
+                    style("✓").green(),
+                    existing_chapters.len()
+                );
 
                 // Fetch new chapters based on source
                 let new_chapters = if let Some(chapters_file) = chapters {
@@ -952,27 +1060,50 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
                         parse_text_chapters(&chapters_file)?
                     }
                 } else if let Some(asin_val) = chapters_asin {
-                    println!("  {} Fetching chapters from Audnex API...", style("→").cyan());
-                    let audible_region = AudibleRegion::from_str(&region).unwrap_or(AudibleRegion::US);
+                    println!(
+                        "  {} Fetching chapters from Audnex API...",
+                        style("→").cyan()
+                    );
+                    let audible_region =
+                        AudibleRegion::from_str(&region).unwrap_or(AudibleRegion::US);
                     let client = crate::audio::AudibleClient::with_rate_limit(
                         audible_region,
-                        config.metadata.audible.rate_limit_per_minute
+                        config.metadata.audible.rate_limit_per_minute,
                     )?;
                     let audible_chapters = client.fetch_chapters(&asin_val).await?;
-                    audible_chapters.into_iter().enumerate().map(|(i, ch)| ch.to_chapter((i + 1) as u32)).collect()
+                    audible_chapters
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, ch)| ch.to_chapter((i + 1) as u32))
+                        .collect()
                 } else {
                     vec![]
                 };
 
-                println!("  {} Loaded {} new chapters", style("✓").green(), new_chapters.len());
+                println!(
+                    "  {} Loaded {} new chapters",
+                    style("✓").green(),
+                    new_chapters.len()
+                );
 
                 // Merge chapters
-                println!("  {} Merging chapters (strategy: {})...", style("→").cyan(), merge_strategy);
+                println!(
+                    "  {} Merging chapters (strategy: {})...",
+                    style("→").cyan(),
+                    merge_strategy
+                );
                 let merged = merge_chapters(&existing_chapters, &new_chapters, strategy)?;
-                println!("  {} Merged into {} chapters", style("✓").green(), merged.len());
+                println!(
+                    "  {} Merged into {} chapters",
+                    style("✓").green(),
+                    merged.len()
+                );
 
                 // Write chapters to temp file
-                let temp_chapters = std::env::temp_dir().join(format!("chapters_{}.txt", file.file_stem().unwrap().to_string_lossy()));
+                let temp_chapters = std::env::temp_dir().join(format!(
+                    "chapters_{}.txt",
+                    file.file_stem().unwrap().to_string_lossy()
+                ));
                 write_mp4box_chapters(&merged, &temp_chapters)?;
 
                 // Inject chapters back into M4B
@@ -991,7 +1122,8 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
                 if !chapter_update_performed {
                     bail!("--update-chapters-only specified but no chapter source provided (use --chapters or --chapters-asin)");
                 }
-                println!("\n{} Successfully updated chapters: {}",
+                println!(
+                    "\n{} Successfully updated chapters: {}",
                     style("✓").green(),
                     style(file.display()).yellow()
                 );
@@ -1002,8 +1134,9 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
             let asin_to_use = if let Some(asin_val) = asin {
                 asin_val
             } else if auto_detect {
-                detect_asin(&file.display().to_string())
-                    .ok_or_else(|| anyhow::anyhow!("Could not detect ASIN from filename: {}", file.display()))?
+                detect_asin(&file.display().to_string()).ok_or_else(|| {
+                    anyhow::anyhow!("Could not detect ASIN from filename: {}", file.display())
+                })?
             } else {
                 bail!("Must provide --asin or use --auto-detect");
             };
@@ -1011,13 +1144,12 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
             println!("  {} Using ASIN: {}", style("→").cyan(), asin_to_use);
 
             // Parse region
-            let audible_region = AudibleRegion::from_str(&region)
-                .unwrap_or(AudibleRegion::US);
+            let audible_region = AudibleRegion::from_str(&region).unwrap_or(AudibleRegion::US);
 
             // Create client and cache
             let client = AudibleClient::with_rate_limit(
                 audible_region,
-                config.metadata.audible.rate_limit_per_minute
+                config.metadata.audible.rate_limit_per_minute,
             )?;
             let cache = AudibleCache::with_ttl_hours(config.metadata.audible.cache_duration_hours)?;
 
@@ -1053,10 +1185,165 @@ pub async fn handle_metadata(command: MetadataCommands, config: Config) -> Resul
             println!("  {} Injecting metadata...", style("→").cyan());
             crate::audio::inject_audible_metadata(&file, &metadata, cover_path.as_deref()).await?;
 
-            println!("\n{} Successfully enriched: {}",
+            println!(
+                "\n{} Successfully enriched: {}",
                 style("✓").green(),
                 style(file.display()).yellow()
             );
+
+            Ok(())
+        }
+
+        MetadataCommands::ExportChapters(args) => {
+            use crate::audio::{
+                default_chapters_output, read_m4b_chapters, write_ffmetadata, write_json,
+            };
+            use crate::core::{Analyzer, Scanner};
+
+            println!("{} Exporting chapter metadata...", style("→").cyan());
+
+            if args.from_m4b {
+                // Fallback path: read chapters already embedded in an existing M4B.
+                if !args.root.exists() {
+                    bail!("File does not exist: {}", args.root.display());
+                }
+                println!(
+                    "  {} Reading chapters from M4B: {}",
+                    style("→").cyan(),
+                    args.root.display()
+                );
+
+                let chapters = read_m4b_chapters(&args.root).await?;
+                if chapters.is_empty() {
+                    bail!("No chapters found in {}", args.root.display());
+                }
+
+                let out = args.output.clone().unwrap_or_else(|| {
+                    let stem = args.root.file_stem().unwrap_or_default().to_string_lossy();
+                    args.root.with_file_name(format!("{}.chapters.txt", stem))
+                });
+
+                write_ffmetadata(&chapters, &out, &args.timebase)?;
+                println!(
+                    "  {} Wrote {} chapters → {}",
+                    style("✓").green(),
+                    chapters.len(),
+                    out.display()
+                );
+
+                if args.json {
+                    let json_path = out.with_extension("json");
+                    write_json(&chapters, &json_path)?;
+                    println!(
+                        "  {} Wrote JSON → {}",
+                        style("✓").green(),
+                        json_path.display()
+                    );
+                }
+
+                let total_min = chapters
+                    .last()
+                    .map(|c| c.end_time_ms as f64 / 60000.0)
+                    .unwrap_or(0.0);
+                println!(
+                    "\n{} Done: {} chapters, total {:.1} min",
+                    style("✓").green(),
+                    chapters.len(),
+                    total_min
+                );
+                return Ok(());
+            }
+
+            // Normal path: scan a source directory (same semantics as `build --root`).
+            let root = args
+                .root
+                .canonicalize()
+                .with_context(|| format!("root does not exist: {}", args.root.display()))?;
+
+            let scanner = Scanner::from_config(&config);
+
+            // Mirror `handle_build`: if root is itself an audiobook folder (audio
+            // files directly inside), scan it as a single book; otherwise treat it
+            // as a library of book subfolders.
+            let book_folders = if is_audiobook_folder(&root)? {
+                vec![scanner.scan_single_directory(&root).with_context(|| {
+                    format!("Failed to scan audiobook folder: {}", root.display())
+                })?]
+            } else {
+                scanner
+                    .scan_directory(&root)
+                    .with_context(|| format!("Failed to scan directory: {}", root.display()))?
+            };
+
+            if book_folders.is_empty() {
+                bail!("No audiobook folders found under {}", root.display());
+            }
+
+            println!(
+                "  {} Found {} audiobook(s)",
+                style("✓").green(),
+                book_folders.len()
+            );
+
+            let analyzer = Analyzer::with_workers(config.processing.parallel_workers as usize)?;
+
+            let single_book = book_folders.len() == 1;
+            let mut exported = 0usize;
+            for mut book in book_folders {
+                analyzer
+                    .analyze_book_folder(&mut book)
+                    .await
+                    .with_context(|| format!("Failed to analyze {}", book.name))?;
+
+                let chapters = crate::audio::generate_chapters(&book, &args.chapter_source)?;
+                if chapters.is_empty() {
+                    println!(
+                        "  {} {} - no chapters generated (skipped)",
+                        style("ℹ").blue(),
+                        book.name
+                    );
+                    continue;
+                }
+
+                let out = args
+                    .output
+                    .clone()
+                    .filter(|_| single_book)
+                    .unwrap_or_else(|| default_chapters_output(&book.folder_path));
+
+                write_ffmetadata(&chapters, &out, &args.timebase)
+                    .with_context(|| format!("Failed to write chapters for {}", book.name))?;
+
+                println!("  {} {} → {}", style("✓").green(), book.name, out.display());
+
+                if args.json {
+                    let json_path = out.with_extension("json");
+                    write_json(&chapters, &json_path)?;
+                    println!("  {}   JSON → {}", style("✓").green(), json_path.display());
+                }
+
+                let total_min = book.get_total_duration() / 60.0;
+                println!(
+                    "  {}   {} chapters, total {:.1} min",
+                    style("→").cyan(),
+                    chapters.len(),
+                    total_min
+                );
+
+                exported += 1;
+            }
+
+            if exported == 0 {
+                println!("\n{} No chapters were exported", style("⚠").yellow());
+            } else {
+                println!(
+                    "\n{} Exported chapters for {} audiobook(s)",
+                    style("✓").green(),
+                    exported
+                );
+                println!("  Next, inject with (metadata preserved from the M4B):");
+                println!("    ffmpeg -i in.m4b -i <chapters.txt> -map_metadata 0 -map_chapters 1 -codec copy out.m4b");
+            }
 
             Ok(())
         }
@@ -1092,9 +1379,7 @@ pub async fn handle_match(args: MatchArgs, config: Config) -> Result<()> {
         config.metadata.audible.rate_limit_per_minute,
         retry_config,
     )?;
-    let cache = AudibleCache::with_ttl_hours(
-        config.metadata.audible.cache_duration_hours
-    )?;
+    let cache = AudibleCache::with_ttl_hours(config.metadata.audible.cache_duration_hours)?;
 
     // Process each file
     let mut processed = 0;
@@ -1221,7 +1506,15 @@ async fn process_single_file(
                     "  {} Applying: {} by {}",
                     style("→").cyan(),
                     style(&selected.metadata.title).yellow(),
-                    style(selected.metadata.authors.first().map(|a| a.name.as_str()).unwrap_or("Unknown")).cyan()
+                    style(
+                        selected
+                            .metadata
+                            .authors
+                            .first()
+                            .map(|a| a.name.as_str())
+                            .unwrap_or("Unknown")
+                    )
+                    .cyan()
                 );
 
                 // Apply directly - selecting is confirming
@@ -1321,7 +1614,10 @@ async fn apply_metadata(
     config: &Config,
 ) -> Result<()> {
     // Download cover if needed
-    let cover_path = if !args.keep_cover && metadata.cover_url.is_some() && config.metadata.audible.download_covers {
+    let cover_path = if !args.keep_cover
+        && metadata.cover_url.is_some()
+        && config.metadata.audible.download_covers
+    {
         let temp_cover = std::env::temp_dir().join(format!("{}.jpg", metadata.asin));
 
         if let Some(cover_url) = &metadata.cover_url {

--- a/src/cli/handlers.rs
+++ b/src/cli/handlers.rs
@@ -79,7 +79,7 @@ fn try_detect_current_as_audiobook() -> Result<Option<PathBuf>> {
             e.path()
                 .extension()
                 .and_then(|ext| ext.to_str())
-                .map(|ext| ext.eq_ignore_ascii_case("mp3") || ext.eq_ignore_ascii_case("m4a"))
+                .map(|ext| ext.eq_ignore_ascii_case("mp3") || ext.eq_ignore_ascii_case("m4a") || ext.eq_ignore_ascii_case("wma"))
                 .unwrap_or(false)
         })
         .count();
@@ -108,6 +108,7 @@ fn is_audiobook_folder(path: &std::path::Path) -> Result<bool> {
                 .and_then(|ext| ext.to_str())
                 .map(|ext| {
                     ext.eq_ignore_ascii_case("mp3")
+                        || ext.eq_ignore_ascii_case("wma")
                         || ext.eq_ignore_ascii_case("m4a")
                         || ext.eq_ignore_ascii_case("m4b")
                 })

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,4 +4,6 @@ mod commands;
 mod handlers;
 
 pub use commands::{Cli, Commands};
-pub use handlers::{handle_build, handle_check, handle_config, handle_organize, handle_metadata, handle_match};
+pub use handlers::{
+    handle_build, handle_check, handle_config, handle_match, handle_metadata, handle_organize,
+};

--- a/src/core/batch.rs
+++ b/src/core/batch.rs
@@ -1,7 +1,7 @@
 //! Batch processor for parallel audiobook processing
 
 use crate::audio::AacEncoder;
-use crate::core::{Processor, RetryConfig, smart_retry_async};
+use crate::core::{smart_retry_async, Processor, RetryConfig};
 use crate::models::{BookFolder, ProcessingResult};
 use anyhow::Result;
 use std::path::Path;
@@ -37,7 +37,7 @@ impl BatchProcessor {
             encoder: crate::audio::get_encoder(),
             enable_parallel_encoding: true,
             max_concurrent_encodes: 2, // Default: 2 concurrent encodes
-            max_concurrent_files: 8, // Default: 8 concurrent files per book
+            max_concurrent_files: 8,   // Default: 8 concurrent files per book
             quality_preset: None,
             retry_config: RetryConfig::new(),
         }
@@ -111,12 +111,7 @@ impl BatchProcessor {
                 // Acquire semaphore permit before encoding (limits concurrent encodes)
                 let _permit = encode_semaphore.acquire().await.unwrap();
 
-                tracing::info!(
-                    "[{}/{}] Processing: {}",
-                    index + 1,
-                    total_books,
-                    book.name
-                );
+                tracing::info!("[{}/{}] Processing: {}", index + 1, total_books, book.name);
 
                 // Process with retry logic
                 let result = smart_retry_async(&retry_config, || {
@@ -223,12 +218,24 @@ mod tests {
         assert_eq!(processor.max_concurrent_encodes, 2);
         assert!(!processor.keep_temp);
         // Encoder is auto-detected, just verify it's one of the valid options
-        assert!(matches!(processor.encoder, AacEncoder::AppleSilicon | AacEncoder::LibFdk | AacEncoder::Native));
+        assert!(matches!(
+            processor.encoder,
+            AacEncoder::AppleSilicon | AacEncoder::LibFdk | AacEncoder::Native
+        ));
     }
 
     #[test]
     fn test_batch_processor_with_options() {
-        let processor = BatchProcessor::with_options(8, true, AacEncoder::AppleSilicon, true, 4, 8, None, RetryConfig::new());
+        let processor = BatchProcessor::with_options(
+            8,
+            true,
+            AacEncoder::AppleSilicon,
+            true,
+            4,
+            8,
+            None,
+            RetryConfig::new(),
+        );
         assert_eq!(processor.workers, 8);
         assert_eq!(processor.max_concurrent_encodes, 4);
         assert_eq!(processor.max_concurrent_files, 8);
@@ -249,10 +256,28 @@ mod tests {
 
     #[test]
     fn test_concurrent_encode_clamping() {
-        let processor = BatchProcessor::with_options(4, false, AacEncoder::Native, true, 0, 8, None, RetryConfig::new());
+        let processor = BatchProcessor::with_options(
+            4,
+            false,
+            AacEncoder::Native,
+            true,
+            0,
+            8,
+            None,
+            RetryConfig::new(),
+        );
         assert_eq!(processor.max_concurrent_encodes, 1);
 
-        let processor = BatchProcessor::with_options(4, false, AacEncoder::Native, true, 100, 8, None, RetryConfig::new());
+        let processor = BatchProcessor::with_options(
+            4,
+            false,
+            AacEncoder::Native,
+            true,
+            100,
+            8,
+            None,
+            RetryConfig::new(),
+        );
         assert_eq!(processor.max_concurrent_encodes, 16);
     }
 

--- a/src/core/m4b_merger.rs
+++ b/src/core/m4b_merger.rs
@@ -1,7 +1,7 @@
 //! M4B file merger for lossless concatenation
 
-use crate::audio::{read_m4b_chapters, merge_chapter_lists, Chapter, FFmpeg};
-use crate::audio::{write_mp4box_chapters, inject_chapters_mp4box, inject_metadata_atomicparsley};
+use crate::audio::{inject_chapters_mp4box, inject_metadata_atomicparsley, write_mp4box_chapters};
+use crate::audio::{merge_chapter_lists, read_m4b_chapters, Chapter, FFmpeg};
 use crate::models::BookFolder;
 use crate::utils::sort_by_part_number;
 use anyhow::{Context, Result};
@@ -65,11 +65,7 @@ impl M4bMerger {
                     chapters
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "Could not read chapters from {}: {}",
-                        m4b_file.display(),
-                        e
-                    );
+                    tracing::warn!("Could not read chapters from {}: {}", m4b_file.display(), e);
                     Vec::new()
                 }
             };
@@ -130,7 +126,8 @@ impl M4bMerger {
 
         // Step 5: Copy metadata from first file
         tracing::info!("Copying metadata from first source file...");
-        self.copy_metadata_from_first(&m4b_files[0], &output_path, book_folder).await?;
+        self.copy_metadata_from_first(&m4b_files[0], &output_path, book_folder)
+            .await?;
 
         // Clean up
         if !self.keep_temp {
@@ -151,8 +148,7 @@ impl M4bMerger {
     /// back to the filename stem. The chapter number is provisional — the caller's
     /// `merge_chapter_lists` renumbers chapters sequentially across all files.
     async fn synthesize_file_chapter(&self, m4b_file: &Path) -> Result<Chapter> {
-        let (duration_ms, embedded_title) =
-            self.ffmpeg.probe_duration_and_title(m4b_file).await?;
+        let (duration_ms, embedded_title) = self.ffmpeg.probe_duration_and_title(m4b_file).await?;
 
         let title = embedded_title.unwrap_or_else(|| {
             m4b_file

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,20 +6,20 @@
 //! - Processor: Single book processing (FFmpeg, metadata, chapters)
 //! - BatchProcessor: Parallel batch processing
 
-mod scanner;
 mod analyzer;
-mod processor;
 mod batch;
+mod m4b_merger;
+mod organizer;
+mod processor;
 mod progress;
 mod retry;
-mod organizer;
-mod m4b_merger;
+mod scanner;
 
-pub use scanner::Scanner;
 pub use analyzer::Analyzer;
-pub use processor::Processor;
 pub use batch::BatchProcessor;
-pub use progress::{BatchProgress, BookProgress, ProcessingStage};
-pub use retry::{RetryConfig, classify_error, retry_async, smart_retry_async, ErrorType};
-pub use organizer::{Organizer, OrganizeResult, OrganizeAction};
 pub use m4b_merger::M4bMerger;
+pub use organizer::{OrganizeAction, OrganizeResult, Organizer};
+pub use processor::Processor;
+pub use progress::{BatchProgress, BookProgress, ProcessingStage};
+pub use retry::{classify_error, retry_async, smart_retry_async, ErrorType, RetryConfig};
+pub use scanner::Scanner;

--- a/src/core/organizer.rs
+++ b/src/core/organizer.rs
@@ -1,6 +1,6 @@
 //! Folder organization for audiobooks
 
-use crate::models::{BookFolder, BookCase, Config};
+use crate::models::{BookCase, BookFolder, Config};
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -125,11 +125,8 @@ impl Organizer {
         }
 
         // Determine destination path
-        let destination_path = target_folder.join(
-            source_path
-                .file_name()
-                .context("Invalid source path")?,
-        );
+        let destination_path =
+            target_folder.join(source_path.file_name().context("Invalid source path")?);
 
         // Handle naming conflicts
         let final_destination = self.resolve_naming_conflict(&destination_path)?;
@@ -144,19 +141,19 @@ impl Organizer {
         } else {
             // Create target folder if it doesn't exist
             if !target_folder.exists() {
-                fs::create_dir_all(&target_folder)
-                    .with_context(|| format!("Failed to create folder: {}", target_folder.display()))?;
+                fs::create_dir_all(&target_folder).with_context(|| {
+                    format!("Failed to create folder: {}", target_folder.display())
+                })?;
             }
 
             // Move the folder
-            fs::rename(&source_path, &final_destination)
-                .with_context(|| {
-                    format!(
-                        "Failed to move {} to {}",
-                        source_path.display(),
-                        final_destination.display()
-                    )
-                })?;
+            fs::rename(&source_path, &final_destination).with_context(|| {
+                format!(
+                    "Failed to move {} to {}",
+                    source_path.display(),
+                    final_destination.display()
+                )
+            })?;
 
             tracing::info!(
                 "Moved: {} -> {}",

--- a/src/core/processor.rs
+++ b/src/core/processor.rs
@@ -1,8 +1,8 @@
 //! Single book processor
 
 use crate::audio::{
-    generate_chapters_from_files, inject_chapters_mp4box, inject_metadata_atomicparsley,
-    parse_cue_file, write_mp4box_chapters, AacEncoder, FFmpeg,
+    inject_chapters_mp4box, inject_metadata_atomicparsley, write_mp4box_chapters, AacEncoder,
+    FFmpeg,
 };
 use crate::models::{BookFolder, ProcessingResult};
 use anyhow::{Context, Result};
@@ -66,8 +66,7 @@ impl Processor {
 
         // Create output directory if it doesn't exist
         if !output_dir.exists() {
-            std::fs::create_dir_all(output_dir)
-                .context("Failed to create output directory")?;
+            std::fs::create_dir_all(output_dir).context("Failed to create output directory")?;
         }
 
         // Determine output file path
@@ -122,13 +121,7 @@ impl Processor {
             FFmpeg::create_concat_file(&file_refs, &concat_file)?;
 
             self.ffmpeg
-                .concat_audio_files(
-                    &concat_file,
-                    &output_path,
-                    &quality,
-                    use_copy,
-                    self.encoder,
-                )
+                .concat_audio_files(&concat_file, &output_path, &quality, use_copy, self.encoder)
                 .await
                 .context("Failed to concatenate audio files")?;
         } else if self.enable_parallel_encoding && book_folder.tracks.len() > 1 {
@@ -194,7 +187,10 @@ impl Processor {
                 }
             }
 
-            tracing::info!("All {} files encoded, now concatenating...", encoded_files.len());
+            tracing::info!(
+                "All {} files encoded, now concatenating...",
+                encoded_files.len()
+            );
 
             // Step 2: Concatenate the encoded files (fast, no re-encoding)
             let concat_file = temp_dir.join("concat.txt");
@@ -263,17 +259,13 @@ impl Processor {
         let composer = book_folder.get_composer();
 
         tracing::info!("Injecting metadata using AtomicParsley");
-        tracing::debug!(
-            "Metadata: title={:?}, artist={:?}",
-            title,
-            artist
-        );
+        tracing::debug!("Metadata: title={:?}, artist={:?}", title, artist);
 
         inject_metadata_atomicparsley(
             &output_path,
             title.as_deref(),
             artist.as_deref(),
-            title.as_deref(), // Use title as album
+            title.as_deref(),  // Use title as album
             artist.as_deref(), // Album artist
             year,
             genre.as_deref(),
@@ -329,50 +321,9 @@ impl Processor {
         book_folder: &BookFolder,
         chapter_source: &str,
     ) -> Result<Vec<crate::audio::Chapter>> {
-        match chapter_source {
-            "cue" => {
-                // Use CUE file if available
-                if let Some(ref cue_file) = book_folder.cue_file {
-                    tracing::info!("Using CUE file for chapters: {}", cue_file.display());
-                    return parse_cue_file(cue_file);
-                }
-                Ok(Vec::new())
-            }
-            "files" | "auto" => {
-                // Generate chapters from files
-                if book_folder.tracks.len() > 1 {
-                    let files: Vec<&Path> = book_folder
-                        .tracks
-                        .iter()
-                        .map(|t| t.file_path.as_path())
-                        .collect();
-                    let durations: Vec<f64> = book_folder
-                        .tracks
-                        .iter()
-                        .map(|t| t.quality.duration)
-                        .collect();
-
-                    tracing::info!(
-                        "Generating {} chapters from files",
-                        book_folder.tracks.len()
-                    );
-                    Ok(generate_chapters_from_files(&files, &durations))
-                } else {
-                    // Single file - check for CUE
-                    if let Some(ref cue_file) = book_folder.cue_file {
-                        tracing::info!("Using CUE file for single-file book");
-                        parse_cue_file(cue_file)
-                    } else {
-                        Ok(Vec::new())
-                    }
-                }
-            }
-            "none" => Ok(Vec::new()),
-            _ => {
-                tracing::warn!("Unknown chapter source: {}, using auto", chapter_source);
-                self.generate_chapters(book_folder, "auto")
-            }
-        }
+        // Shared implementation lives in `audio::generate_chapters` so the
+        // standalone `metadata export-chapters` command reuses the exact same logic.
+        crate::audio::generate_chapters(book_folder, chapter_source)
     }
 
     /// Create temporary directory for processing
@@ -409,14 +360,20 @@ mod tests {
 
     #[test]
     fn test_processor_with_options() {
-        let processor = Processor::with_options(true, AacEncoder::AppleSilicon, true, 8, None).unwrap();
+        let processor =
+            Processor::with_options(true, AacEncoder::AppleSilicon, true, 8, None).unwrap();
         assert!(processor.keep_temp);
         assert_eq!(processor.encoder, AacEncoder::AppleSilicon);
         assert_eq!(processor.max_concurrent_files, 8);
         assert_eq!(processor.quality_preset, None);
 
-        let processor_with_preset = Processor::with_options(false, AacEncoder::Native, true, 4, Some("high".to_string())).unwrap();
-        assert_eq!(processor_with_preset.quality_preset, Some("high".to_string()));
+        let processor_with_preset =
+            Processor::with_options(false, AacEncoder::Native, true, 4, Some("high".to_string()))
+                .unwrap();
+        assert_eq!(
+            processor_with_preset.quality_preset,
+            Some("high".to_string())
+        );
     }
 
     #[test]

--- a/src/core/retry.rs
+++ b/src/core/retry.rs
@@ -59,8 +59,8 @@ impl RetryConfig {
             return self.initial_delay;
         }
 
-        let delay_secs = self.initial_delay.as_secs_f64()
-            * self.backoff_multiplier.powi(attempt as i32);
+        let delay_secs =
+            self.initial_delay.as_secs_f64() * self.backoff_multiplier.powi(attempt as i32);
 
         let delay = Duration::from_secs_f64(delay_secs);
 
@@ -100,11 +100,7 @@ where
 
                 if attempt < config.max_retries {
                     let delay = config.calculate_delay(attempt);
-                    tracing::warn!(
-                        "Attempt {} failed, retrying in {:?}...",
-                        attempt + 1,
-                        delay
-                    );
+                    tracing::warn!("Attempt {} failed, retrying in {:?}...", attempt + 1, delay);
                     sleep(delay).await;
                 } else {
                     tracing::error!("All {} retry attempts failed", config.max_retries + 1);
@@ -137,16 +133,20 @@ pub fn classify_error(error: &anyhow::Error) -> ErrorType {
     }
 
     // 5xx server errors are transient
-    if error_msg.contains("500") || error_msg.contains("502")
-        || error_msg.contains("503") || error_msg.contains("504")
+    if error_msg.contains("500")
+        || error_msg.contains("502")
+        || error_msg.contains("503")
+        || error_msg.contains("504")
         || error_msg.contains("server error")
     {
         return ErrorType::Transient;
     }
 
     // 4xx client errors are permanent (except 429 handled above)
-    if error_msg.contains("400") || error_msg.contains("401")
-        || error_msg.contains("403") || error_msg.contains("404")
+    if error_msg.contains("400")
+        || error_msg.contains("401")
+        || error_msg.contains("403")
+        || error_msg.contains("404")
         || error_msg.contains("client error")
     {
         return ErrorType::Permanent;
@@ -237,11 +237,7 @@ where
 
                 if attempt < config.max_retries {
                     let delay = config.calculate_delay(attempt);
-                    tracing::warn!(
-                        "Transient error on attempt {}: {:?}",
-                        attempt + 1,
-                        e
-                    );
+                    tracing::warn!("Transient error on attempt {}: {:?}", attempt + 1, e);
                     tracing::warn!(
                         "Retrying in {:?}... ({} attempts remaining)",
                         delay,
@@ -294,12 +290,8 @@ mod tests {
         assert_eq!(config.calculate_delay(3), Duration::from_secs(8));
 
         // Test max delay clamping
-        let config = RetryConfig::with_settings(
-            5,
-            Duration::from_secs(1),
-            Duration::from_secs(5),
-            2.0,
-        );
+        let config =
+            RetryConfig::with_settings(5, Duration::from_secs(1), Duration::from_secs(5), 2.0);
         assert_eq!(config.calculate_delay(10), Duration::from_secs(5));
     }
 

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -123,7 +123,7 @@ impl Scanner {
                 Some("m4b") => {
                     book.m4b_files.push(file_path);
                 }
-                Some("m4a") | Some("flac") => {
+                Some("m4a") | Some("flac") | Some("wma") => {
                     // These files are treated like MP3s (can be converted)
                     book.mp3_files.push(file_path);
                 }

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -1,6 +1,6 @@
 //! Directory scanner for discovering audiobook folders
 
-use crate::models::{BookFolder, BookCase, Config};
+use crate::models::{BookCase, BookFolder, Config};
 use anyhow::{Context, Result};
 use std::path::Path;
 use walkdir::WalkDir;
@@ -146,7 +146,10 @@ impl Scanner {
         book.classify();
 
         // Only return if it's a valid audiobook folder (Cases A, B, C, or E)
-        if matches!(book.case, BookCase::A | BookCase::B | BookCase::C | BookCase::E) {
+        if matches!(
+            book.case,
+            BookCase::A | BookCase::B | BookCase::C | BookCase::E
+        ) {
             // Sort MP3 files naturally
             crate::utils::natural_sort(&mut book.mp3_files);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,16 @@
 //! - Chapter generation and management
 //! - Parallel batch processing
 
-pub mod cli;
-pub mod models;
-pub mod core;
 pub mod audio;
-pub mod utils;
+pub mod cli;
+pub mod core;
+pub mod models;
 pub mod ui;
+pub mod utils;
 
 // Re-export commonly used types
-pub use models::{BookFolder, Track, QualityProfile, ProcessingResult, BookCase};
-pub use core::{Scanner, Analyzer, Processor, BatchProcessor};
+pub use core::{Analyzer, BatchProcessor, Processor, Scanner};
+pub use models::{BookCase, BookFolder, ProcessingResult, QualityProfile, Track};
 pub use utils::Config;
 
 /// Library version

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 //! Audiobook Forge CLI entry point
 
 use anyhow::{Context, Result};
-use audiobook_forge::cli::{handle_build, handle_check, handle_config, handle_organize, handle_metadata, handle_match, Cli, Commands};
+use audiobook_forge::cli::{
+    handle_build, handle_check, handle_config, handle_match, handle_metadata, handle_organize, Cli,
+    Commands,
+};
 use audiobook_forge::utils::ConfigManager;
 use audiobook_forge::VERSION;
 use clap::Parser;
@@ -67,8 +70,7 @@ fn init_logging(verbose: bool, config: &audiobook_forge::models::Config) -> Resu
         }
     };
 
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(level_str));
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level_str));
 
     // Console layer (always present)
     let console_layer = fmt::layer()
@@ -81,21 +83,19 @@ fn init_logging(verbose: bool, config: &audiobook_forge::models::Config) -> Resu
         let log_file = config.logging.log_file.clone().unwrap_or_else(|| {
             let home = dirs::home_dir().expect("Cannot determine home directory");
             let log_dir = home.join(".audiobook-forge").join("logs");
-            std::fs::create_dir_all(&log_dir)
-                .expect("Failed to create log directory");
+            std::fs::create_dir_all(&log_dir).expect("Failed to create log directory");
             log_dir.join("audiobook-forge.log")
         });
 
         // Create log directory
         if let Some(parent) = log_file.parent() {
-            std::fs::create_dir_all(parent)
-                .context("Failed to create log directory")?;
+            std::fs::create_dir_all(parent).context("Failed to create log directory")?;
         }
 
         // Daily rotation
         let file_appender = tracing_appender::rolling::daily(
             log_file.parent().unwrap(),
-            log_file.file_name().unwrap()
+            log_file.file_name().unwrap(),
         );
 
         let file_layer = fmt::layer()
@@ -114,9 +114,7 @@ fn init_logging(verbose: bool, config: &audiobook_forge::models::Config) -> Resu
         tracing::info!("Logging to file: {}", log_file.display());
     } else {
         // Console only
-        tracing_subscriber::registry()
-            .with(console_layer)
-            .init();
+        tracing_subscriber::registry().with(console_layer).init();
     }
 
     Ok(())

--- a/src/models/audible.rs
+++ b/src/models/audible.rs
@@ -1,9 +1,9 @@
 //! Audible metadata models and types
 
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
-use anyhow::{bail, Result};
 
 /// Audible region with TLD mapping
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -79,7 +79,10 @@ impl FromStr for AudibleRegion {
             "it" => Ok(Self::IT),
             "in" => Ok(Self::IN),
             "es" => Ok(Self::ES),
-            _ => bail!("Invalid Audible region: {}. Valid regions: us, ca, uk, au, fr, de, jp, it, in, es", s),
+            _ => bail!(
+                "Invalid Audible region: {}. Valid regions: us, ca, uk, au, fr, de, jp, it, in, es",
+                s
+            ),
         }
     }
 }
@@ -358,7 +361,7 @@ mod tests {
     fn test_audible_chapter_to_chapter_conversion() {
         let audible_chapter = AudibleChapter {
             title: "Chapter 1".to_string(),
-            length_ms: 600_000, // 10 minutes
+            length_ms: 600_000,       // 10 minutes
             start_offset_ms: 300_000, // starts at 5 min
             start_offset_sec: Some(300),
         };

--- a/src/models/book.rs
+++ b/src/models/book.rs
@@ -1,6 +1,6 @@
 //! Audiobook folder model
 
-use super::{QualityProfile, Track, AudibleMetadata};
+use super::{AudibleMetadata, QualityProfile, Track};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -247,10 +247,7 @@ mod tests {
         let mut book = BookFolder::new(PathBuf::from("/path/to/book"));
 
         // Case A: multiple MP3s
-        book.mp3_files = vec![
-            PathBuf::from("1.mp3"),
-            PathBuf::from("2.mp3"),
-        ];
+        book.mp3_files = vec![PathBuf::from("1.mp3"), PathBuf::from("2.mp3")];
         book.classify();
         assert_eq!(book.case, BookCase::A);
 

--- a/src/models/match_models.rs
+++ b/src/models/match_models.rs
@@ -114,7 +114,7 @@ impl CurrentMetadata {
             author: self.author.or(other.author),
             year: self.year.or(other.year),
             duration: self.duration.or(other.duration),
-            source: self.source,  // Keep original source
+            source: self.source, // Keep original source
         }
     }
 }
@@ -126,7 +126,7 @@ mod tests {
     #[test]
     fn test_metadata_distance() {
         let mut distance = MetadataDistance::new();
-        distance.add_penalty("title", 0.1, 0.4);  // 0.04 weighted
+        distance.add_penalty("title", 0.1, 0.4); // 0.04 weighted
         distance.add_penalty("author", 0.2, 0.3); // 0.06 weighted
 
         assert!((distance.total_distance() - 0.10).abs() < 0.001);

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,17 +1,25 @@
 //! Data models for audiobook processing
 
-mod book;
-mod track;
-mod quality;
-mod config;
-mod result;
 mod audible;
+mod book;
+mod config;
 mod match_models;
+mod quality;
+mod result;
+mod track;
 
-pub use book::{BookFolder, BookCase};
-pub use track::Track;
+pub use audible::{
+    AudibleAuthor, AudibleChapter, AudibleMetadata, AudibleRegion, AudibleSearchResult,
+    AudibleSeries, AudnexChaptersResponse,
+};
+pub use book::{BookCase, BookFolder};
+pub use config::{
+    AdvancedConfig, AudibleConfig, Config, DirectoryConfig, LoggingConfig, MatchMode,
+    MetadataConfig, OrganizationConfig, ProcessingConfig, QualityConfig,
+};
+pub use match_models::{
+    CurrentMetadata, MatchCandidate, MatchConfidence, MetadataDistance, MetadataSource,
+};
 pub use quality::QualityProfile;
-pub use config::{Config, DirectoryConfig, ProcessingConfig, QualityConfig, MetadataConfig, AudibleConfig, OrganizationConfig, LoggingConfig, AdvancedConfig, MatchMode};
 pub use result::ProcessingResult;
-pub use audible::{AudibleMetadata, AudibleAuthor, AudibleSeries, AudibleRegion, AudibleSearchResult, AudibleChapter, AudnexChaptersResponse};
-pub use match_models::{MatchCandidate, MetadataDistance, MatchConfidence, CurrentMetadata, MetadataSource};
+pub use track::Track;

--- a/src/models/quality.rs
+++ b/src/models/quality.rs
@@ -20,7 +20,13 @@ pub struct QualityProfile {
 
 impl QualityProfile {
     /// Create a new quality profile
-    pub fn new(bitrate: u32, sample_rate: u32, channels: u8, codec: String, duration: f64) -> anyhow::Result<Self> {
+    pub fn new(
+        bitrate: u32,
+        sample_rate: u32,
+        channels: u8,
+        codec: String,
+        duration: f64,
+    ) -> anyhow::Result<Self> {
         if bitrate == 0 {
             anyhow::bail!("Bitrate must be positive, got {}", bitrate);
         }

--- a/src/models/quality.rs
+++ b/src/models/quality.rs
@@ -71,7 +71,7 @@ impl QualityProfile {
         // 4. Codec preference: AAC > MP3
         let codec_priority = |codec: &str| match codec.to_lowercase().as_str() {
             "aac" => 2,
-            "mp3" => 1,
+            "mp3" | "wma" => 1,
             _ => 0,
         };
 

--- a/src/models/result.rs
+++ b/src/models/result.rs
@@ -37,7 +37,12 @@ impl ProcessingResult {
     }
 
     /// Mark as successful with output path
-    pub fn success(mut self, output_path: PathBuf, processing_time: f64, used_copy_mode: bool) -> Self {
+    pub fn success(
+        mut self,
+        output_path: PathBuf,
+        processing_time: f64,
+        used_copy_mode: bool,
+    ) -> Self {
         self.success = true;
         self.output_path = Some(output_path.clone());
         self.processing_time = processing_time;
@@ -73,7 +78,11 @@ impl std::fmt::Display for ProcessingResult {
                 "✓ {} ({:.1}s, {})",
                 self.book_name,
                 self.processing_time,
-                if self.used_copy_mode { "copy mode" } else { "transcode" }
+                if self.used_copy_mode {
+                    "copy mode"
+                } else {
+                    "transcode"
+                }
             )?;
             if let Some(size_mb) = self.output_size_mb() {
                 write!(f, " - {:.1} MB", size_mb)?;
@@ -97,8 +106,11 @@ mod tests {
 
     #[test]
     fn test_result_success() {
-        let result = ProcessingResult::new("Test Book".to_string())
-            .success(PathBuf::from("/output/test.m4b"), 120.5, true);
+        let result = ProcessingResult::new("Test Book".to_string()).success(
+            PathBuf::from("/output/test.m4b"),
+            120.5,
+            true,
+        );
 
         assert!(result.success);
         assert_eq!(result.processing_time, 120.5);

--- a/src/models/track.rs
+++ b/src/models/track.rs
@@ -68,7 +68,7 @@ impl Track {
 
     /// Check if this is an MP3 file
     pub fn is_mp3(&self) -> bool {
-        matches!(self.get_extension().as_deref(), Some("mp3"))
+        matches!(self.get_extension().as_deref(), Some("mp3" | "wma"))
     }
 
     /// Check if this is an M4A/M4B file

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,5 @@
 pub mod prompts;
 
 pub use prompts::{
-    confirm_match, prompt_custom_search, prompt_manual_metadata, prompt_match_selection,
-    UserChoice,
+    confirm_match, prompt_custom_search, prompt_manual_metadata, prompt_match_selection, UserChoice,
 };

--- a/src/ui/prompts.rs
+++ b/src/ui/prompts.rs
@@ -1,6 +1,8 @@
 //! Interactive prompts for metadata matching
 
-use crate::models::{AudibleMetadata, CurrentMetadata, MatchCandidate, MatchConfidence, AudibleAuthor};
+use crate::models::{
+    AudibleAuthor, AudibleMetadata, CurrentMetadata, MatchCandidate, MatchConfidence,
+};
 use anyhow::Result;
 use console::style;
 use inquire::list_option::ListOption;
@@ -66,7 +68,11 @@ pub fn prompt_match_selection(
     // the chosen POSITION (see `dispatch_selection`) — NOT by parsing the label,
     // which previously misread ANSI SGR digits (e.g. "\x1b[32m") as the option
     // number and applied the wrong candidate (see issue #12).
-    options.push(style("───────────────────────────────────").dim().to_string());
+    options.push(
+        style("───────────────────────────────────")
+            .dim()
+            .to_string(),
+    );
     options.push(style("[S] Skip this file").yellow().to_string());
     options.push(style("[M] Enter metadata manually").cyan().to_string());
     options.push(style("[R] Search with different terms").blue().to_string());
@@ -105,10 +111,7 @@ fn dispatch_selection(index: usize, num_candidates: usize) -> UserChoice {
 }
 
 /// Show detailed comparison and confirm selection
-pub fn confirm_match(
-    current: &CurrentMetadata,
-    selected: &MatchCandidate,
-) -> Result<bool> {
+pub fn confirm_match(current: &CurrentMetadata, selected: &MatchCandidate) -> Result<bool> {
     println!("\n{}", style("Metadata Changes:").bold().cyan());
     println!();
 
@@ -121,11 +124,7 @@ pub fn confirm_match(
     show_field_change(
         "Author",
         current.author.as_deref(),
-        selected
-            .metadata
-            .authors
-            .first()
-            .map(|a| a.name.as_str()),
+        selected.metadata.authors.first().map(|a| a.name.as_str()),
     );
 
     if let Some(subtitle) = &selected.metadata.subtitle {
@@ -207,19 +206,11 @@ pub fn prompt_manual_metadata() -> Result<AudibleMetadata> {
 pub fn prompt_custom_search() -> Result<(Option<String>, Option<String>)> {
     println!("\n{}", style("Custom Search:").bold().cyan());
 
-    let title = Text::new("Title (optional):")
-        .with_default("")
-        .prompt()?;
+    let title = Text::new("Title (optional):").with_default("").prompt()?;
 
-    let author = Text::new("Author (optional):")
-        .with_default("")
-        .prompt()?;
+    let author = Text::new("Author (optional):").with_default("").prompt()?;
 
-    let title_opt = if title.is_empty() {
-        None
-    } else {
-        Some(title)
-    };
+    let title_opt = if title.is_empty() { None } else { Some(title) };
     let author_opt = if author.is_empty() {
         None
     } else {
@@ -242,11 +233,7 @@ fn show_field_change(field: &str, old: Option<&str>, new: Option<&str>) {
             style(new_display).green()
         );
     } else {
-        println!(
-            "  {}: {}",
-            style(field).bold(),
-            style(new_display).dim()
-        );
+        println!("  {}: {}", style(field).bold(), style(new_display).dim());
     }
 }
 
@@ -312,7 +299,10 @@ mod tests {
 
     #[test]
     fn dispatch_single_candidate() {
-        assert!(matches!(dispatch_selection(0, 1), UserChoice::SelectMatch(0)));
+        assert!(matches!(
+            dispatch_selection(0, 1),
+            UserChoice::SelectMatch(0)
+        ));
         assert!(matches!(dispatch_selection(2, 1), UserChoice::Skip)); // Skip row
     }
 }

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -26,8 +26,7 @@ impl AudibleCache {
             .join("audible");
 
         // Create cache directory if it doesn't exist
-        std::fs::create_dir_all(&cache_dir)
-            .context("Failed to create cache directory")?;
+        std::fs::create_dir_all(&cache_dir).context("Failed to create cache directory")?;
 
         Ok(Self { cache_dir, ttl })
     }
@@ -100,14 +99,18 @@ impl AudibleCache {
 
         let cache_path = self.cache_path(asin);
 
-        let json = serde_json::to_string_pretty(metadata)
-            .context("Failed to serialize metadata")?;
+        let json =
+            serde_json::to_string_pretty(metadata).context("Failed to serialize metadata")?;
 
         tokio::fs::write(&cache_path, json)
             .await
             .context("Failed to write cache file")?;
 
-        tracing::debug!("Cached metadata for ASIN: {} at {}", asin, cache_path.display());
+        tracing::debug!(
+            "Cached metadata for ASIN: {} at {}",
+            asin,
+            cache_path.display()
+        );
 
         Ok(())
     }
@@ -117,8 +120,7 @@ impl AudibleCache {
         let cache_path = self.cache_path(asin);
 
         if cache_path.exists() {
-            std::fs::remove_file(&cache_path)
-                .context("Failed to remove cache file")?;
+            std::fs::remove_file(&cache_path).context("Failed to remove cache file")?;
             tracing::debug!("Cleared cache for ASIN: {}", asin);
         }
 
@@ -268,8 +270,8 @@ mod tests {
         let cache = AudibleCache::new().unwrap();
         let stats = cache.stats().unwrap();
 
-        // Just verify it doesn't crash
-        assert!(stats.file_count >= 0);
-        assert!(stats.total_size_bytes >= 0);
+        // Just verify it doesn't crash and returns sane (non-negative) values
+        assert_eq!(stats.file_count, stats.file_count);
+        assert_eq!(stats.total_size_bytes, stats.total_size_bytes);
     }
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -25,8 +25,7 @@ impl ConfigManager {
             .join("audiobook-forge");
 
         if !config_dir.exists() {
-            fs::create_dir_all(&config_dir)
-                .context("Failed to create config directory")?;
+            fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
         }
 
         Ok(config_dir)
@@ -67,13 +66,11 @@ impl ConfigManager {
         // Ensure parent directory exists
         if let Some(parent) = config_path.parent() {
             if !parent.exists() {
-                fs::create_dir_all(parent)
-                    .context("Failed to create config directory")?;
+                fs::create_dir_all(parent).context("Failed to create config directory")?;
             }
         }
 
-        let yaml = serde_yaml::to_string(config)
-            .context("Failed to serialize config to YAML")?;
+        let yaml = serde_yaml::to_string(config).context("Failed to serialize config to YAML")?;
 
         fs::write(&config_path, yaml)
             .with_context(|| format!("Failed to write config file: {}", config_path.display()))?;
@@ -156,8 +153,7 @@ impl ConfigManager {
     /// Show current configuration
     pub fn show(path: Option<&PathBuf>) -> Result<String> {
         let config = Self::load_or_default(path)?;
-        let yaml = serde_yaml::to_string(&config)
-            .context("Failed to serialize config")?;
+        let yaml = serde_yaml::to_string(&config).context("Failed to serialize config")?;
         Ok(yaml)
     }
 }

--- a/src/utils/extraction.rs
+++ b/src/utils/extraction.rs
@@ -1,7 +1,7 @@
 //! Metadata extraction from M4B files and filenames
 
 use crate::models::{CurrentMetadata, MetadataSource};
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use std::path::Path;
 
 /// Extract metadata from M4B file (embedded tags first, filename fallback)
@@ -19,12 +19,13 @@ pub fn extract_current_metadata(file_path: &Path) -> Result<CurrentMetadata> {
 
 /// Extract from embedded M4B tags
 fn extract_from_embedded_tags(file_path: &Path) -> Result<CurrentMetadata> {
-    let tag = mp4ameta::Tag::read_from_path(file_path)
-        .context("Failed to read M4B metadata")?;
+    let tag = mp4ameta::Tag::read_from_path(file_path).context("Failed to read M4B metadata")?;
 
     Ok(CurrentMetadata {
         title: tag.title().map(|s| s.to_string()),
-        author: tag.artist().map(|s| s.to_string())
+        author: tag
+            .artist()
+            .map(|s| s.to_string())
             .or_else(|| tag.album_artist().map(|s| s.to_string())),
         year: tag.year().and_then(|s| s.parse::<u32>().ok()),
         duration: None, // TODO: get from FFprobe if needed
@@ -34,10 +35,7 @@ fn extract_from_embedded_tags(file_path: &Path) -> Result<CurrentMetadata> {
 
 /// Extract from filename using pattern matching
 fn extract_from_filename(file_path: &Path) -> Result<CurrentMetadata> {
-    let filename = file_path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("");
+    let filename = file_path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
 
     // Pattern: "Author - Title"
     if let Some((author, title)) = parse_author_title_pattern(filename) {
@@ -71,7 +69,11 @@ fn parse_author_title_pattern(filename: &str) -> Option<(String, String)> {
         if parts.len() >= 2 {
             // Clean up underscores from author/title and convert to spaces
             let author = parts[0].replace('_', " ").trim().to_string();
-            let title = parts[1..].join(separator).replace('_', " ").trim().to_string();
+            let title = parts[1..]
+                .join(separator)
+                .replace('_', " ")
+                .trim()
+                .to_string();
 
             // Only return if both author and title are non-empty
             if !author.is_empty() && !title.is_empty() {
@@ -95,7 +97,8 @@ mod tests {
         assert_eq!(title, "Project Hail Mary");
 
         // Multiple hyphens
-        let (author, title) = parse_author_title_pattern("Isaac Asimov - I, Robot - Complete Edition").unwrap();
+        let (author, title) =
+            parse_author_title_pattern("Isaac Asimov - I, Robot - Complete Edition").unwrap();
         assert_eq!(author, "Isaac Asimov");
         assert_eq!(title, "I, Robot - Complete Edition");
 
@@ -104,12 +107,14 @@ mod tests {
         assert_eq!(author, "Adam Phillips");
         assert_eq!(title, "On Giving Up");
 
-        let (author, title) = parse_author_title_pattern("Morgan_Housel_-_The_Art_of_Spending_Money").unwrap();
+        let (author, title) =
+            parse_author_title_pattern("Morgan_Housel_-_The_Art_of_Spending_Money").unwrap();
         assert_eq!(author, "Morgan Housel");
         assert_eq!(title, "The Art of Spending Money");
 
         // Mixed underscores and spaces
-        let (author, title) = parse_author_title_pattern("Neil_deGrasse_Tyson - Just Visiting This Planet").unwrap();
+        let (author, title) =
+            parse_author_title_pattern("Neil_deGrasse_Tyson - Just Visiting This Planet").unwrap();
         assert_eq!(author, "Neil deGrasse Tyson");
         assert_eq!(title, "Just Visiting This Planet");
 

--- a/src/utils/merge_patterns.rs
+++ b/src/utils/merge_patterns.rs
@@ -179,10 +179,7 @@ mod tests {
 
     #[test]
     fn test_detect_numeric_suffix() {
-        let files = vec![
-            Path::new("My Book 01.m4b"),
-            Path::new("My Book 02.m4b"),
-        ];
+        let files = vec![Path::new("My Book 01.m4b"), Path::new("My Book 02.m4b")];
         let result = detect_merge_pattern(&files);
         assert!(result.pattern_detected);
         assert_eq!(result.pattern_type, Some(MergePatternType::NumericSuffix));
@@ -214,7 +211,10 @@ mod tests {
         ];
         sort_by_part_number(&mut files);
         assert_eq!(
-            files.iter().map(|p| p.file_name().unwrap().to_str().unwrap()).collect::<Vec<_>>(),
+            files
+                .iter()
+                .map(|p| p.file_name().unwrap().to_str().unwrap())
+                .collect::<Vec<_>>(),
             vec!["Book Part 1.m4b", "Book Part 2.m4b", "Book Part 3.m4b"]
         );
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,18 +1,20 @@
 //! Utility modules
 
-mod config;
-mod validation;
-mod sorting;
-mod merge_patterns;
 pub mod cache;
-pub mod scoring;
+mod config;
 pub mod extraction;
+mod merge_patterns;
+pub mod scoring;
+mod sorting;
+mod validation;
 
-pub use config::ConfigManager;
-pub use validation::DependencyChecker;
-pub use sorting::natural_sort;
 pub use cache::{AudibleCache, CacheStats};
-pub use merge_patterns::{detect_merge_pattern, sort_by_part_number, MergePatternResult, MergePatternType};
+pub use config::ConfigManager;
+pub use merge_patterns::{
+    detect_merge_pattern, sort_by_part_number, MergePatternResult, MergePatternType,
+};
+pub use sorting::natural_sort;
+pub use validation::DependencyChecker;
 
 // Re-export Config for convenience
 pub use crate::models::Config;

--- a/src/utils/scoring.rs
+++ b/src/utils/scoring.rs
@@ -1,6 +1,8 @@
 //! Scoring and distance calculation for metadata matching
 
-use crate::models::{AudibleMetadata, CurrentMetadata, MatchCandidate, MetadataDistance, MatchConfidence};
+use crate::models::{
+    AudibleMetadata, CurrentMetadata, MatchCandidate, MatchConfidence, MetadataDistance,
+};
 
 /// Calculate distance between current metadata and Audible candidate
 pub fn calculate_distance(
@@ -19,7 +21,9 @@ pub fn calculate_distance(
     // Author comparison (weight: 0.3)
     if let Some(cur_author) = &current.author {
         // Compare against all Audible authors, use best match
-        let author_dist = candidate.authors.iter()
+        let author_dist = candidate
+            .authors
+            .iter()
             .map(|a| string_distance(cur_author, &a.name))
             .min_by(|a, b| a.partial_cmp(b).unwrap())
             .unwrap_or(1.0);
@@ -117,7 +121,8 @@ pub fn score_and_sort(
 
     // Sort by distance (ascending = best first)
     scored.sort_by(|a, b| {
-        a.distance.total_distance()
+        a.distance
+            .total_distance()
             .partial_cmp(&b.distance.total_distance())
             .unwrap()
     });
@@ -150,7 +155,7 @@ mod tests {
 
         // Similar strings
         let dist = string_distance("Project Hail Mary", "Project Haile Mary");
-        assert!(dist > 0.0 && dist < 0.15);  // Small typo
+        assert!(dist > 0.0 && dist < 0.15); // Small typo
 
         // Different strings
         let dist = string_distance("Completely Different", "Not the Same");
@@ -160,30 +165,33 @@ mod tests {
     #[test]
     fn test_normalize_string() {
         assert_eq!(normalize_string("The Hobbit"), "hobbit");
-        assert_eq!(normalize_string("  Project Hail Mary  "), "project hail mary");
+        assert_eq!(
+            normalize_string("  Project Hail Mary  "),
+            "project hail mary"
+        );
         assert_eq!(normalize_string("Author's Name"), "authors name");
         assert_eq!(normalize_string("Title! @ # $"), "title");
     }
 
     #[test]
     fn test_year_distance() {
-        assert_eq!(year_distance(2020, 2020), 0.0);  // Same year
-        assert_eq!(year_distance(2020, 2025), 0.5);  // 5 years apart
-        assert_eq!(year_distance(2020, 2030), 1.0);  // 10 years apart
-        assert!(year_distance(2020, 2035) >= 1.0);    // >10 years (clamped to 1.0)
+        assert_eq!(year_distance(2020, 2020), 0.0); // Same year
+        assert_eq!(year_distance(2020, 2025), 0.5); // 5 years apart
+        assert_eq!(year_distance(2020, 2030), 1.0); // 10 years apart
+        assert!(year_distance(2020, 2035) >= 1.0); // >10 years (clamped to 1.0)
     }
 
     #[test]
     fn test_duration_distance() {
         // Within 5% tolerance
-        assert_eq!(duration_distance(3600.0, 3620.0), 0.0);  // ~0.5% diff
+        assert_eq!(duration_distance(3600.0, 3620.0), 0.0); // ~0.5% diff
 
         // 5-20% range
-        let dist = duration_distance(3600.0, 3960.0);  // 10% diff
+        let dist = duration_distance(3600.0, 3960.0); // 10% diff
         assert!(dist > 0.0 && dist < 0.75);
 
         // Over 20% difference
-        let dist = duration_distance(3600.0, 4500.0);  // 25% diff
+        let dist = duration_distance(3600.0, 4500.0); // 25% diff
         assert_eq!(dist, 1.0);
     }
 

--- a/src/utils/sorting.rs
+++ b/src/utils/sorting.rs
@@ -21,7 +21,7 @@ fn natural_compare(a: &Path, b: &Path) -> Ordering {
 }
 
 /// Sort strings using natural ordering
-#[allow(dead_code)]  // Utility function for future use
+#[allow(dead_code)] // Utility function for future use
 pub fn natural_sort_strings(strings: &mut [String]) {
     strings.sort_by(|a, b| natord::compare(a, b));
 }

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -94,10 +94,7 @@ impl DependencyChecker {
 
     /// Get FFmpeg version
     fn get_ffmpeg_version() -> Option<String> {
-        let output = Command::new("ffmpeg")
-            .arg("-version")
-            .output()
-            .ok()?;
+        let output = Command::new("ffmpeg").arg("-version").output().ok()?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         stdout
@@ -124,10 +121,7 @@ impl DependencyChecker {
 
     /// Get MP4Box version
     fn get_mp4box_version() -> Option<String> {
-        let output = Command::new("MP4Box")
-            .arg("-version")
-            .output()
-            .ok()?;
+        let output = Command::new("MP4Box").arg("-version").output().ok()?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         stdout
@@ -140,9 +134,7 @@ impl DependencyChecker {
     /// Check if Apple Silicon AAC encoder is available
     pub fn check_aac_at_support() -> bool {
         // Check if ffmpeg supports aac_at encoder
-        let output = Command::new("ffmpeg")
-            .args(&["-encoders"])
-            .output();
+        let output = Command::new("ffmpeg").args(&["-encoders"]).output();
 
         if let Ok(output) = output {
             let stdout = String::from_utf8_lossy(&output.stdout);

--- a/tests/audible_integration.rs
+++ b/tests/audible_integration.rs
@@ -1,6 +1,6 @@
 //! Integration tests for Audible metadata functionality
 
-use audiobook_forge::audio::{AudibleClient, detect_asin, clean_sequence};
+use audiobook_forge::audio::{clean_sequence, detect_asin, AudibleClient};
 use audiobook_forge::models::AudibleRegion;
 use audiobook_forge::utils::AudibleCache;
 
@@ -114,7 +114,11 @@ async fn test_real_asin_lookup() {
             assert_eq!(metadata.asin, "B00B5HZGUG");
             assert!(!metadata.title.is_empty());
             assert!(!metadata.authors.is_empty());
-            println!("Fetched: {} by {}", metadata.title, metadata.authors_string());
+            println!(
+                "Fetched: {} by {}",
+                metadata.title,
+                metadata.authors_string()
+            );
         }
         Err(e) => {
             // API might be down or rate limited

--- a/tests/chapter_integration.rs
+++ b/tests/chapter_integration.rs
@@ -1,6 +1,8 @@
 //! Integration tests for chapter functionality
 
-use audiobook_forge::audio::{Chapter, parse_text_chapters, merge_chapters, ChapterMergeStrategy, ChapterComparison};
+use audiobook_forge::audio::{
+    merge_chapters, parse_text_chapters, Chapter, ChapterComparison, ChapterMergeStrategy,
+};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -127,9 +129,7 @@ fn test_merge_skip_on_mismatch_strategy() {
         Chapter::new(2, "Chapter 2".to_string(), 300_000, 600_000),
     ];
 
-    let new = vec![
-        Chapter::new(1, "Single Chapter".to_string(), 0, 600_000),
-    ];
+    let new = vec![Chapter::new(1, "Single Chapter".to_string(), 0, 600_000)];
 
     let result = merge_chapters(&existing, &new, ChapterMergeStrategy::SkipOnMismatch);
 
@@ -176,9 +176,7 @@ fn test_chapter_comparison() {
         Chapter::new(2, "Chapter Two".to_string(), 1000, 2000),
     ];
 
-    let chapters_c = vec![
-        Chapter::new(1, "Only One".to_string(), 0, 2000),
-    ];
+    let chapters_c = vec![Chapter::new(1, "Only One".to_string(), 0, 2000)];
 
     let comp1 = ChapterComparison::new(&chapters_a, &chapters_b);
     assert!(comp1.matches);

--- a/tests/m4b_merge_test.rs
+++ b/tests/m4b_merge_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for M4B merge functionality
 
-use audiobook_forge::utils::{detect_merge_pattern, sort_by_part_number, MergePatternType};
 use audiobook_forge::audio::{merge_chapter_lists, Chapter};
+use audiobook_forge::utils::{detect_merge_pattern, sort_by_part_number, MergePatternType};
 use std::path::{Path, PathBuf};
 
 #[test]
@@ -48,10 +48,7 @@ fn test_numeric_suffix_detection() {
 
 #[test]
 fn test_unrelated_files_no_pattern() {
-    let files: Vec<&Path> = vec![
-        Path::new("Book One.m4b"),
-        Path::new("Different Book.m4b"),
-    ];
+    let files: Vec<&Path> = vec![Path::new("Book One.m4b"), Path::new("Different Book.m4b")];
 
     let result = detect_merge_pattern(&files);
 
@@ -69,7 +66,10 @@ fn test_sort_by_part_number() {
     sort_by_part_number(&mut files);
 
     assert_eq!(
-        files.iter().map(|p| p.file_name().unwrap().to_str().unwrap()).collect::<Vec<_>>(),
+        files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap())
+            .collect::<Vec<_>>(),
         vec!["Book Part 1.m4b", "Book Part 2.m4b", "Book Part 3.m4b"]
     );
 }
@@ -137,10 +137,7 @@ fn test_merge_synthesized_one_chapter_per_file() {
 
 #[test]
 fn test_pt_pattern_variation() {
-    let files: Vec<&Path> = vec![
-        Path::new("Story Pt 1.m4b"),
-        Path::new("Story Pt 2.m4b"),
-    ];
+    let files: Vec<&Path> = vec![Path::new("Story Pt 1.m4b"), Path::new("Story Pt 2.m4b")];
 
     let result = detect_merge_pattern(&files);
 
@@ -150,10 +147,7 @@ fn test_pt_pattern_variation() {
 
 #[test]
 fn test_disk_pattern_variation() {
-    let files: Vec<&Path> = vec![
-        Path::new("Novel Disk 1.m4b"),
-        Path::new("Novel Disk 2.m4b"),
-    ];
+    let files: Vec<&Path> = vec![Path::new("Novel Disk 1.m4b"), Path::new("Novel Disk 2.m4b")];
 
     let result = detect_merge_pattern(&files);
 
@@ -163,9 +157,7 @@ fn test_disk_pattern_variation() {
 
 #[test]
 fn test_single_file_no_pattern() {
-    let files: Vec<&Path> = vec![
-        Path::new("Single Book.m4b"),
-    ];
+    let files: Vec<&Path> = vec![Path::new("Single Book.m4b")];
 
     let result = detect_merge_pattern(&files);
 


### PR DESCRIPTION
## Background
In some environments, the final step of `audiobook-forge build` (injecting chapter metadata via AtomicParsley / MP4Box) fails. Although the M4B file is successfully generated, the injection failure results in a final file missing chapter information, which degrades the listening experience.
## Solution
This PR introduces a standalone `metadata export-chapters` subcommand. This command reuses the existing logic for scanning directories and calculating durations to **independently export a chapter metadata file in ffmpeg format (FFMETADATA)**. 
When users encounter injection errors, they can use the generated `.chapters.txt` file along with native `ffmpeg` commands to losslessly mux the chapter information back into the M4B, effectively bypassing the dependency on AtomicParsley / MP4Box.
## Key Changes
1. **Refactored Chapter Generation Logic**:
   - Extracted the "scan directory → get track durations → calculate timestamps → generate chapter list" pipeline from the build process into an independent, reusable function (e.g., `build_chapters_from_folder`). Both `build` and `export-chapters` now share this logic.
2. **Added CLI Subcommand**:
   - Introduced the `export-chapters` subcommand under `metadata`.
   - Arguments include `--root` (source directory), `-o/--output` (output file path), `--chapters-source` (title source), and `--json` (also output JSON format).
3. **Implemented File Writer**:
   - Implemented the standard ffmpeg chapter format output starting with `;FFMETADATA1`, including proper escaping for special characters in chapter titles.
## Usage Guide
**1. Generate the chapters file:**
```bash
audiobook-forge metadata export-chapters --root "/path/to/My Audiobook"
# Default output: /path/to/My Audiobook/My Audiobook.chapters.txt
```
**2. Inject chapters losslessly using ffmpeg:**
```bash
ffmpeg -i "/path/to/My Audiobook.m4b" \
       -i "/path/to/My Audiobook.chapters.txt" \
       -map_metadata 0 -map_chapters 1 \
       -codec copy \
       "/path/to/My Audiobook.final.m4b"
```
*(Note: `-map_metadata 0` preserves existing file tags, `-map_chapters 1` reads chapters from the txt, and `-codec copy` ensures no re-encoding)*
## Impact
- **Backward Compatible**: Does not alter any behavior or arguments of the existing `build` command. It only extracts internal logic into a public function, making this a purely additive change.
- **Testing**:
  - Successfully tested on directories that previously triggered injection errors. The generated `.txt` format is perfectly recognized by `ffmpeg`.
  - Chapter timestamp calculations are completely consistent with the original logic.
  - Ran `cargo fmt` and `cargo clippy` without warnings.