### PR TITLE
fix(scanner): combine named multi-disc directories

### DIFF
--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -107,13 +107,24 @@ impl Scanner {
 
         self.scan_files_in_directory(&mut book, path)?;
 
-        // A common layout stores each disc in an immediate child directory.
-        // Include those files in the parent book rather than treating each disc
-        // as an independent audiobook.
+        // Only fold immediate children into the parent when the parent has no
+        // direct audio and every child is a sequential disc/part directory.
+        // This preserves nested layouts such as Author/Book One and
+        // Author/Book Two as two independent books.
+        let parent_has_audio = !book.mp3_files.is_empty() || !book.m4b_files.is_empty();
+        let mut child_directories = Vec::new();
         for entry in std::fs::read_dir(path).context("Failed to read directory")? {
             let entry = entry.context("Failed to read directory entry")?;
             let child_path = entry.path();
             if child_path.is_dir() && !self.is_hidden(&child_path) {
+                child_directories.push(child_path);
+            }
+        }
+
+        if !parent_has_audio
+            && crate::utils::are_sequential_part_directories(&child_directories)
+        {
+            for child_path in child_directories {
                 self.scan_files_in_directory(&mut book, &child_path)?;
             }
         }

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -56,13 +56,15 @@ impl Scanner {
         let mut book_folders = Vec::new();
 
         // Walk through directory tree, but only go 2 levels deep
-        // (root → book folders → files)
-        for entry in WalkDir::new(root)
+        // (root → book folders → disc folders). Once a book is found, skip its
+        // descendants so disc folders are not emitted as separate audiobooks.
+        let mut entries = WalkDir::new(root)
             .max_depth(2)
             .min_depth(1)
             .into_iter()
-            .filter_entry(|e| e.file_type().is_dir())
-        {
+            .filter_entry(|e| e.file_type().is_dir());
+
+        while let Some(entry) = entries.next() {
             let entry = entry.context("Failed to read directory entry")?;
             let path = entry.path();
 
@@ -74,6 +76,7 @@ impl Scanner {
             // Check if this is a valid audiobook folder
             if let Some(book) = self.scan_folder(path)? {
                 book_folders.push(book);
+                entries.skip_current_dir();
             }
         }
 
@@ -102,43 +105,16 @@ impl Scanner {
     fn scan_folder(&self, path: &Path) -> Result<Option<BookFolder>> {
         let mut book = BookFolder::new(path.to_path_buf());
 
-        // Find audio files
+        self.scan_files_in_directory(&mut book, path)?;
+
+        // A common layout stores each disc in an immediate child directory.
+        // Include those files in the parent book rather than treating each disc
+        // as an independent audiobook.
         for entry in std::fs::read_dir(path).context("Failed to read directory")? {
             let entry = entry.context("Failed to read directory entry")?;
-            let file_path = entry.path();
-
-            if !file_path.is_file() {
-                continue;
-            }
-
-            let extension = file_path
-                .extension()
-                .and_then(|s| s.to_str())
-                .map(|s| s.to_lowercase());
-
-            match extension.as_deref() {
-                Some("mp3") => {
-                    book.mp3_files.push(file_path);
-                }
-                Some("m4b") => {
-                    book.m4b_files.push(file_path);
-                }
-                Some("m4a") | Some("flac") => {
-                    // These files are treated like MP3s (can be converted)
-                    book.mp3_files.push(file_path);
-                }
-                Some("cue") => {
-                    book.cue_file = Some(file_path);
-                }
-                Some("jpg") | Some("png") | Some("jpeg") => {
-                    // Check if this is a cover art file
-                    if book.cover_file.is_none() {
-                        if self.is_cover_art(&file_path) {
-                            book.cover_file = Some(file_path);
-                        }
-                    }
-                }
-                _ => {}
+            let child_path = entry.path();
+            if child_path.is_dir() && !self.is_hidden(&child_path) {
+                self.scan_files_in_directory(&mut book, &child_path)?;
             }
         }
 
@@ -200,6 +176,49 @@ impl Scanner {
         } else {
             Ok(None)
         }
+    }
+
+    /// Add supported audiobook files from one directory to a book.
+    fn scan_files_in_directory(&self, book: &mut BookFolder, directory: &Path) -> Result<()> {
+        for entry in std::fs::read_dir(directory).context("Failed to read directory")? {
+            let entry = entry.context("Failed to read directory entry")?;
+            let file_path = entry.path();
+
+            if !file_path.is_file() {
+                continue;
+            }
+
+            let extension = file_path
+                .extension()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_lowercase());
+
+            match extension.as_deref() {
+                Some("mp3") => {
+                    book.mp3_files.push(file_path);
+                }
+                Some("m4b") => {
+                    book.m4b_files.push(file_path);
+                }
+                Some("m4a") | Some("flac") => {
+                    // These files are treated like MP3s (can be converted)
+                    book.mp3_files.push(file_path);
+                }
+                Some("cue") => {
+                    book.cue_file = Some(file_path);
+                }
+                Some("jpg") | Some("png") | Some("jpeg") => {
+                    // Check if this is a cover art file
+                    if book.cover_file.is_none() {
+                        if self.is_cover_art(&file_path) {
+                            book.cover_file = Some(file_path);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
     }
 
     /// Check if a path is hidden (starts with .)

--- a/src/utils/merge_patterns.rs
+++ b/src/utils/merge_patterns.rs
@@ -150,6 +150,43 @@ pub fn sort_by_part_number(files: &mut [std::path::PathBuf]) {
     });
 }
 
+/// Check whether every directory is a sequential disc/part directory.
+///
+/// Recognized names include `CD1`, `Disc 2`, `Disk3`, `Part 4`, and `Pt. 5`.
+/// Requiring a complete sequential set avoids folding ordinary nested library
+/// layouts such as `Author/Book One` and `Author/Book Two` into one book.
+pub fn are_sequential_part_directories(directories: &[std::path::PathBuf]) -> bool {
+    if directories.len() < 2 {
+        return false;
+    }
+
+    lazy_static::lazy_static! {
+        static ref PART_DIRECTORY_REGEX: Regex = Regex::new(
+            r"(?i)^(?:part|pt\.?|disc|disk|cd)\s*(\d+)$"
+        ).unwrap();
+    }
+
+    let mut numbers = Vec::with_capacity(directories.len());
+    for directory in directories {
+        let Some(name) = directory.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+        let Some(captures) = PART_DIRECTORY_REGEX.captures(name) else {
+            return false;
+        };
+        let Some(number) = captures
+            .get(1)
+            .and_then(|value| value.as_str().parse::<u32>().ok())
+        else {
+            return false;
+        };
+        numbers.push(number);
+    }
+
+    numbers.sort_unstable();
+    numbers == (1..=directories.len() as u32).collect::<Vec<_>>()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,5 +254,20 @@ mod tests {
             files.iter().map(|p| p.file_name().unwrap().to_str().unwrap()).collect::<Vec<_>>(),
             vec!["Book Part 1.m4b", "Book Part 2.m4b", "Book Part 3.m4b"]
         );
+    }
+
+    #[test]
+    fn test_sequential_part_directories() {
+        let disc_directories = vec![
+            std::path::PathBuf::from("CD1"),
+            std::path::PathBuf::from("CD2"),
+        ];
+        assert!(are_sequential_part_directories(&disc_directories));
+
+        let book_directories = vec![
+            std::path::PathBuf::from("Book One"),
+            std::path::PathBuf::from("Book Two"),
+        ];
+        assert!(!are_sequential_part_directories(&book_directories));
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,7 +12,7 @@ pub use config::ConfigManager;
 pub use validation::DependencyChecker;
 pub use sorting::natural_sort;
 pub use cache::{AudibleCache, CacheStats};
-pub use merge_patterns::{detect_merge_pattern, sort_by_part_number, MergePatternResult, MergePatternType};
+pub use merge_patterns::{are_sequential_part_directories, detect_merge_pattern, sort_by_part_number, MergePatternResult, MergePatternType};
 
 // Re-export Config for convenience
 pub use crate::models::Config;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -304,3 +304,24 @@ fn test_scanner_treats_disc_subdirectories_as_one_audiobook() {
         ["CD1", "CD2"]
     );
 }
+
+#[test]
+fn test_scanner_keeps_books_below_author_directory_separate() {
+    let temp_dir = TempDir::new().unwrap();
+    let author = temp_dir.path().join("Author");
+    let book_one = author.join("Book One");
+    let book_two = author.join("Book Two");
+    fs::create_dir_all(&book_one).unwrap();
+    fs::create_dir_all(&book_two).unwrap();
+    fs::write(book_one.join("01.mp3"), b"fake mp3").unwrap();
+    fs::write(book_two.join("01.mp3"), b"fake mp3").unwrap();
+
+    let mut books = Scanner::new().scan_directory(temp_dir.path()).unwrap();
+    books.sort_by(|left, right| left.name.cmp(&right.name));
+
+    assert_eq!(books.len(), 2);
+    assert_eq!(books[0].name, "Book One");
+    assert_eq!(books[1].name, "Book Two");
+    assert_eq!(books[0].mp3_files.len(), 1);
+    assert_eq!(books[1].mp3_files.len(), 1);
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -278,3 +278,29 @@ fn test_m4a_files_treated_as_mp3() {
     assert_eq!(books[0].case, BookCase::A);
     assert_eq!(books[0].mp3_files.len(), 2); // M4A treated as MP3
 }
+
+#[test]
+fn test_scanner_treats_disc_subdirectories_as_one_audiobook() {
+    let temp_dir = TempDir::new().unwrap();
+    let book = temp_dir.path().join("My Book");
+    let cd1 = book.join("CD1");
+    let cd2 = book.join("CD2");
+    fs::create_dir_all(&cd1).unwrap();
+    fs::create_dir_all(&cd2).unwrap();
+    fs::write(cd1.join("01.mp3"), b"fake mp3").unwrap();
+    fs::write(cd2.join("01.mp3"), b"fake mp3").unwrap();
+
+    let books = Scanner::new().scan_directory(temp_dir.path()).unwrap();
+
+    assert_eq!(books.len(), 1);
+    assert_eq!(books[0].name, "My Book");
+    assert_eq!(books[0].mp3_files.len(), 2);
+    assert_eq!(
+        books[0]
+            .mp3_files
+            .iter()
+            .map(|path| path.parent().unwrap().file_name().unwrap().to_string_lossy())
+            .collect::<Vec<_>>(),
+        ["CD1", "CD2"]
+    );
+}


### PR DESCRIPTION
## Problem

A multi-disc audiobook is detected as two books:

```text
My Book/
├── CD1/01.mp3
└── CD2/01.mp3
```

The scanner returns `CD1` and `CD2` - two separate outputs, disc order lost.

## Cause

Directory discovery walks two levels deep, but a candidate folder is judged only on the files directly inside it. `My Book/` has no direct audio, so it is rejected; `CD1/` and `CD2/` each do, so each becomes its own book.

## Fix

Fold subfolders into their parent when, and only when:

1. the parent has no direct audio, and
2. every visible subfolder is a numbered part folder - `CD1`, `Disc 2`, `Disk3`, `Part 4`, `Pt. 5` - and their numbers form a complete `1..n` set.

The parent then becomes one book holding all disc files, and the scan does not descend into it again.

Requiring a *complete numbered set* is what keeps ordinary nested libraries intact: `Author/Book One` + `Author/Book Two` are still two books, because those names are not part folders.

## Tests

- `test_scanner_treats_disc_subdirectories_as_one_audiobook` - CD1 + CD2 → one `My Book`, both tracks, disc order.
- `test_scanner_keeps_books_below_author_directory_separate` - Author/Book One + Book Two → still two books.
- `test_sequential_part_directories` - the naming and numbering rule on its own.

## Known limit

A disc set with an extra sibling folder (`Artwork/`, `Scans/`) does not qualify and falls back to today's behavior, one book per disc.

