### PR TITLE
fix(chapters): offset M4B chapters by media duration

### DIFF
--- a/src/audio/chapter_import.rs
+++ b/src/audio/chapter_import.rs
@@ -411,27 +411,24 @@ fn merge_keep_timestamps(existing: &[Chapter], new: &[Chapter]) -> Result<Vec<Ch
 
 /// Merge chapter lists from multiple M4B files with adjusted timestamps
 ///
-/// Takes chapter lists and their source file durations (both one entry per M4B)
-/// and combines them into a single list with correctly offset timestamps.
+/// Takes chapter lists paired with their source file durations and combines
+/// them into a single list with correctly offset timestamps.
 /// Each subsequent file's chapters are offset by the cumulative media duration
 /// of previous files, including audio after the final chapter marker.
-pub fn merge_chapter_lists(
-    chapter_lists: &[Vec<Chapter>],
-    source_durations_ms: &[u64],
-) -> Vec<Chapter> {
-    if chapter_lists.is_empty() {
+pub fn merge_chapter_lists(chapter_parts: &[(Vec<Chapter>, u64)]) -> Vec<Chapter> {
+    if chapter_parts.is_empty() {
         return Vec::new();
     }
 
-    if chapter_lists.len() == 1 {
-        return chapter_lists[0].clone();
+    if chapter_parts.len() == 1 {
+        return chapter_parts[0].0.clone();
     }
 
     let mut merged = Vec::new();
     let mut cumulative_offset: u64 = 0;
     let mut chapter_number: u32 = 1;
 
-    for (chapters, duration_ms) in chapter_lists.iter().zip(source_durations_ms) {
+    for (chapters, duration_ms) in chapter_parts {
         for chapter in chapters {
             let adjusted_start = chapter.start_time_ms + cumulative_offset;
             let adjusted_end = chapter.end_time_ms + cumulative_offset;
@@ -665,7 +662,7 @@ mod tests {
             Chapter::new(2, "Part2 Ch2".to_string(), 45_000, 90_000),
         ];
 
-        let merged = merge_chapter_lists(&[chapters1, chapters2], &[120_000, 90_000]);
+        let merged = merge_chapter_lists(&[(chapters1, 120_000), (chapters2, 90_000)]);
 
         assert_eq!(merged.len(), 4);
         // First file's chapters unchanged
@@ -691,7 +688,7 @@ mod tests {
 
     #[test]
     fn test_merge_chapter_lists_empty() {
-        let result = merge_chapter_lists(&[], &[]);
+        let result = merge_chapter_lists(&[]);
         assert!(result.is_empty());
     }
 
@@ -701,7 +698,7 @@ mod tests {
             Chapter::new(1, "Ch1".to_string(), 0, 1000),
             Chapter::new(2, "Ch2".to_string(), 1000, 2000),
         ];
-        let result = merge_chapter_lists(&[chapters.clone()], &[2_000]);
+        let result = merge_chapter_lists(&[(chapters.clone(), 2_000)]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].title, "Ch1");
         assert_eq!(result[1].title, "Ch2");

--- a/src/audio/chapter_import.rs
+++ b/src/audio/chapter_import.rs
@@ -411,10 +411,14 @@ fn merge_keep_timestamps(existing: &[Chapter], new: &[Chapter]) -> Result<Vec<Ch
 
 /// Merge chapter lists from multiple M4B files with adjusted timestamps
 ///
-/// Takes a slice of chapter lists (one per M4B file) and combines them into
-/// a single list with correctly offset timestamps. Each subsequent file's
-/// chapters are offset by the cumulative duration of previous files.
-pub fn merge_chapter_lists(chapter_lists: &[Vec<Chapter>]) -> Vec<Chapter> {
+/// Takes chapter lists and their source file durations (both one entry per M4B)
+/// and combines them into a single list with correctly offset timestamps.
+/// Each subsequent file's chapters are offset by the cumulative media duration
+/// of previous files, including audio after the final chapter marker.
+pub fn merge_chapter_lists(
+    chapter_lists: &[Vec<Chapter>],
+    source_durations_ms: &[u64],
+) -> Vec<Chapter> {
     if chapter_lists.is_empty() {
         return Vec::new();
     }
@@ -427,7 +431,7 @@ pub fn merge_chapter_lists(chapter_lists: &[Vec<Chapter>]) -> Vec<Chapter> {
     let mut cumulative_offset: u64 = 0;
     let mut chapter_number: u32 = 1;
 
-    for chapters in chapter_lists {
+    for (chapters, duration_ms) in chapter_lists.iter().zip(source_durations_ms) {
         for chapter in chapters {
             let adjusted_start = chapter.start_time_ms + cumulative_offset;
             let adjusted_end = chapter.end_time_ms + cumulative_offset;
@@ -441,10 +445,7 @@ pub fn merge_chapter_lists(chapter_lists: &[Vec<Chapter>]) -> Vec<Chapter> {
             chapter_number += 1;
         }
 
-        // Update cumulative offset based on the last chapter's end time
-        if let Some(last) = chapters.last() {
-            cumulative_offset += last.end_time_ms;
-        }
+        cumulative_offset += duration_ms;
     }
 
     merged
@@ -664,7 +665,7 @@ mod tests {
             Chapter::new(2, "Part2 Ch2".to_string(), 45_000, 90_000),
         ];
 
-        let merged = merge_chapter_lists(&[chapters1, chapters2]);
+        let merged = merge_chapter_lists(&[chapters1, chapters2], &[120_000, 90_000]);
 
         assert_eq!(merged.len(), 4);
         // First file's chapters unchanged
@@ -690,7 +691,7 @@ mod tests {
 
     #[test]
     fn test_merge_chapter_lists_empty() {
-        let result = merge_chapter_lists(&[]);
+        let result = merge_chapter_lists(&[], &[]);
         assert!(result.is_empty());
     }
 
@@ -700,7 +701,7 @@ mod tests {
             Chapter::new(1, "Ch1".to_string(), 0, 1000),
             Chapter::new(2, "Ch2".to_string(), 1000, 2000),
         ];
-        let result = merge_chapter_lists(&[chapters.clone()]);
+        let result = merge_chapter_lists(&[chapters.clone()], &[2_000]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].title, "Ch1");
         assert_eq!(result[1].title, "Ch2");

--- a/src/core/m4b_merger.rs
+++ b/src/core/m4b_merger.rs
@@ -52,10 +52,12 @@ impl M4bMerger {
 
         // Step 1: Extract chapters from all files
         tracing::info!("Extracting chapters from source files...");
-        let mut all_chapters: Vec<Vec<Chapter>> = Vec::new();
-        let mut source_durations_ms = Vec::new();
+        let mut chapter_parts: Vec<(Vec<Chapter>, u64)> = Vec::new();
 
         for m4b_file in &m4b_files {
+            // The full media duration is required to position every later
+            // chapter correctly. Continuing without it would knowingly emit
+            // shifted chapter metadata, so a probe failure aborts the merge.
             let (duration_ms, embedded_title) = self
                 .ffmpeg
                 .probe_duration_and_title(m4b_file)
@@ -89,12 +91,11 @@ impl M4bMerger {
                 chapters
             };
 
-            all_chapters.push(chapters);
-            source_durations_ms.push(duration_ms);
+            chapter_parts.push((chapters, duration_ms));
         }
 
         // Merge chapter lists with adjusted timestamps
-        let merged_chapters = merge_chapter_lists(&all_chapters, &source_durations_ms);
+        let merged_chapters = merge_chapter_lists(&chapter_parts);
         tracing::info!("Total merged chapters: {}", merged_chapters.len());
 
         // Step 2: Create concat file for FFmpeg

--- a/src/core/m4b_merger.rs
+++ b/src/core/m4b_merger.rs
@@ -53,8 +53,14 @@ impl M4bMerger {
         // Step 1: Extract chapters from all files
         tracing::info!("Extracting chapters from source files...");
         let mut all_chapters: Vec<Vec<Chapter>> = Vec::new();
+        let mut source_durations_ms = Vec::new();
 
         for m4b_file in &m4b_files {
+            let (duration_ms, embedded_title) = self
+                .ffmpeg
+                .probe_duration_and_title(m4b_file)
+                .await
+                .with_context(|| format!("Failed to determine duration of {}", m4b_file.display()))?;
             let chapters = match read_m4b_chapters(m4b_file).await {
                 Ok(chapters) => {
                     tracing::debug!(
@@ -78,26 +84,17 @@ impl M4bMerger {
             // whole file as a single chapter so merging incremental (one-file-per-
             // chapter) audiobooks still produces a chapterized output (issue #15).
             let chapters = if chapters.is_empty() {
-                match self.synthesize_file_chapter(m4b_file).await {
-                    Ok(chapter) => vec![chapter],
-                    Err(e) => {
-                        tracing::warn!(
-                            "Could not synthesize a chapter for {}: {}",
-                            m4b_file.display(),
-                            e
-                        );
-                        Vec::new()
-                    }
-                }
+                vec![self.synthesize_file_chapter(m4b_file, duration_ms, embedded_title)]
             } else {
                 chapters
             };
 
             all_chapters.push(chapters);
+            source_durations_ms.push(duration_ms);
         }
 
         // Merge chapter lists with adjusted timestamps
-        let merged_chapters = merge_chapter_lists(&all_chapters);
+        let merged_chapters = merge_chapter_lists(&all_chapters, &source_durations_ms);
         tracing::info!("Total merged chapters: {}", merged_chapters.len());
 
         // Step 2: Create concat file for FFmpeg
@@ -150,10 +147,12 @@ impl M4bMerger {
     /// The chapter title is taken from the file's embedded `title` tag, falling
     /// back to the filename stem. The chapter number is provisional — the caller's
     /// `merge_chapter_lists` renumbers chapters sequentially across all files.
-    async fn synthesize_file_chapter(&self, m4b_file: &Path) -> Result<Chapter> {
-        let (duration_ms, embedded_title) =
-            self.ffmpeg.probe_duration_and_title(m4b_file).await?;
-
+    fn synthesize_file_chapter(
+        &self,
+        m4b_file: &Path,
+        duration_ms: u64,
+        embedded_title: Option<String>,
+    ) -> Chapter {
         let title = embedded_title.unwrap_or_else(|| {
             m4b_file
                 .file_stem()
@@ -161,7 +160,7 @@ impl M4bMerger {
                 .unwrap_or_else(|| "Chapter".to_string())
         });
 
-        Ok(Chapter::new(1, title, 0, duration_ms))
+        Chapter::new(1, title, 0, duration_ms)
     }
 
     /// Copy metadata from first source file to output

--- a/tests/m4b_merge_test.rs
+++ b/tests/m4b_merge_test.rs
@@ -86,7 +86,10 @@ fn test_chapter_merge_with_offsets() {
         Chapter::new(2, "Epilogue".to_string(), 600_000, 900_000),
     ];
 
-    let merged = merge_chapter_lists(&[part1_chapters, part2_chapters], &[900_000, 900_000]);
+    let merged = merge_chapter_lists(&[
+        (part1_chapters, 900_000),
+        (part2_chapters, 900_000),
+    ]);
 
     assert_eq!(merged.len(), 4);
 
@@ -112,7 +115,11 @@ fn test_merge_synthesized_one_chapter_per_file() {
     let file2 = vec![Chapter::new(1, "002 Troy".to_string(), 0, 400_000)];
     let file3 = vec![Chapter::new(1, "003 Troy".to_string(), 0, 600_000)];
 
-    let merged = merge_chapter_lists(&[file1, file2, file3], &[500_000, 400_000, 600_000]);
+    let merged = merge_chapter_lists(&[
+        (file1, 500_000),
+        (file2, 400_000),
+        (file3, 600_000),
+    ]);
 
     assert_eq!(merged.len(), 3);
 
@@ -143,7 +150,7 @@ fn test_chapter_offsets_use_source_duration_not_last_chapter_end() {
     ];
     let part2 = vec![Chapter::new(1, "Part 2 Chapter 1".to_string(), 0, 5_000)];
 
-    let merged = merge_chapter_lists(&[part1, part2], &[10_000, 5_000]);
+    let merged = merge_chapter_lists(&[(part1, 10_000), (part2, 5_000)]);
 
     assert_eq!(merged[2].start_time_ms, 10_000);
     assert_eq!(merged[2].end_time_ms, 15_000);

--- a/tests/m4b_merge_test.rs
+++ b/tests/m4b_merge_test.rs
@@ -136,6 +136,20 @@ fn test_merge_synthesized_one_chapter_per_file() {
 }
 
 #[test]
+fn test_chapter_offsets_use_source_duration_not_last_chapter_end() {
+    let part1 = vec![
+        Chapter::new(1, "Part 1 Chapter 1".to_string(), 0, 4_000),
+        Chapter::new(2, "Part 1 Chapter 2".to_string(), 4_000, 9_000),
+    ];
+    let part2 = vec![Chapter::new(1, "Part 2 Chapter 1".to_string(), 0, 5_000)];
+
+    let merged = merge_chapter_lists(&[part1, part2], &[10_000, 5_000]);
+
+    assert_eq!(merged[2].start_time_ms, 10_000);
+    assert_eq!(merged[2].end_time_ms, 15_000);
+}
+
+#[test]
 fn test_pt_pattern_variation() {
     let files: Vec<&Path> = vec![
         Path::new("Story Pt 1.m4b"),

--- a/tests/m4b_merge_test.rs
+++ b/tests/m4b_merge_test.rs
@@ -86,7 +86,7 @@ fn test_chapter_merge_with_offsets() {
         Chapter::new(2, "Epilogue".to_string(), 600_000, 900_000),
     ];
 
-    let merged = merge_chapter_lists(&[part1_chapters, part2_chapters]);
+    let merged = merge_chapter_lists(&[part1_chapters, part2_chapters], &[900_000, 900_000]);
 
     assert_eq!(merged.len(), 4);
 
@@ -112,7 +112,7 @@ fn test_merge_synthesized_one_chapter_per_file() {
     let file2 = vec![Chapter::new(1, "002 Troy".to_string(), 0, 400_000)];
     let file3 = vec![Chapter::new(1, "003 Troy".to_string(), 0, 600_000)];
 
-    let merged = merge_chapter_lists(&[file1, file2, file3]);
+    let merged = merge_chapter_lists(&[file1, file2, file3], &[500_000, 400_000, 600_000]);
 
     assert_eq!(merged.len(), 3);
 


### PR DESCRIPTION
## Problem

Chapters in later parts start too early. Part 1 holds 10s of audio but its last chapter ends at 9s, so part 2's first chapter lands at 9s - a second before the audio it labels. The error accumulates over every following part.

## Cause

`merge_chapter_lists` advanced its running offset by the previous part's **last chapter end**, not by the file's duration. A chapter marker need not reach the end of the media, and the concat demuxer appends whole files, so trailing audio silently vanished from the offset.

## Fix

Probe each source's real duration and offset by that:

```text
cumulative offset += source media duration
```

`merge_chapter_lists` now takes `&[(Vec<Chapter>, u64)]` - each chapter list paired with the duration it came from - so the two can't drift out of sync. The same probe supplies the title and duration used to synthesize a chapter for a source that has none, so chapterless files are not probed twice.

## Behavior change worth knowing

Every source is probed up front, and a probe failure now aborts the merge. Continuing would knowingly write shifted chapter metadata, which is worse than stopping.

## Test

`test_chapter_offsets_use_source_duration_not_last_chapter_end`: a 10s part whose last chapter ends at 9s, then a 5s part. The second part's chapter must span `10,000 → 15,000 ms`; the old code produced `9,000 → 14,000`.

