### PR TITLE
fix(analyzer): preserve natural track order

### DIFF
--- a/src/core/analyzer.rs
+++ b/src/core/analyzer.rs
@@ -96,7 +96,9 @@ impl Default for Analyzer {
 mod tests {
     use super::*;
     use crate::models::QualityProfile;
+    use std::fs;
     use std::path::PathBuf;
+    use tempfile::TempDir;
 
     #[test]
     fn test_analyzer_creation() {
@@ -136,5 +138,44 @@ mod tests {
         ];
 
         assert!(!analyzer.can_use_copy_mode(&book));
+    }
+
+    #[tokio::test]
+    async fn analyzed_tracks_keep_the_scanner_natural_order() {
+        let temp_dir = TempDir::new().unwrap();
+        let probe = temp_dir.path().join("ffprobe");
+        fs::write(
+            &probe,
+            "#!/bin/sh\necho '{\"streams\":[{\"codec_type\":\"audio\",\"codec_name\":\"mp3\",\"sample_rate\":\"44100\",\"channels\":2,\"bit_rate\":\"128000\",\"duration\":\"1.0\"}],\"format\":{\"bit_rate\":\"128000\",\"duration\":\"1.0\"}}'\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&probe, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let mut book = BookFolder::new(temp_dir.path().join("Book"));
+        book.mp3_files = vec![
+            temp_dir.path().join("track1.mp3"),
+            temp_dir.path().join("track2.mp3"),
+            temp_dir.path().join("track10.mp3"),
+        ];
+        for track in &book.mp3_files {
+            fs::write(track, b"not audio").unwrap();
+        }
+
+        let analyzer = Analyzer {
+            ffmpeg: FFmpeg::with_paths("true".to_string(), probe.to_string_lossy().into_owned()),
+            parallel_workers: 3,
+        };
+        analyzer.analyze_book_folder(&mut book).await.unwrap();
+
+        let names: Vec<_> = book
+            .tracks
+            .iter()
+            .map(|track| track.file_path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, ["track1.mp3", "track2.mp3", "track10.mp3"]);
     }
 }

--- a/src/core/analyzer.rs
+++ b/src/core/analyzer.rs
@@ -68,12 +68,7 @@ impl Analyzer {
 
         // `buffer_unordered` completes probes out of order. Restore the scanner's
         // natural order so tracks such as 1, 2, 10 are not emitted as 1, 10, 2.
-        tracks.sort_by(|a, b| {
-            natord::compare(
-                &a.file_path.to_string_lossy(),
-                &b.file_path.to_string_lossy(),
-            )
-        });
+        tracks.sort_by(|a, b| crate::utils::natural_compare(&a.file_path, &b.file_path));
 
         book_folder.tracks = tracks;
 
@@ -101,8 +96,10 @@ impl Default for Analyzer {
 mod tests {
     use super::*;
     use crate::models::QualityProfile;
+    #[cfg(unix)]
     use std::fs;
     use std::path::PathBuf;
+    #[cfg(unix)]
     use tempfile::TempDir;
 
     #[test]
@@ -145,20 +142,18 @@ mod tests {
         assert!(!analyzer.can_use_copy_mode(&book));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn analyzed_tracks_keep_the_scanner_natural_order() {
         let temp_dir = TempDir::new().unwrap();
         let probe = temp_dir.path().join("ffprobe");
         fs::write(
             &probe,
-            "#!/bin/sh\necho '{\"streams\":[{\"codec_type\":\"audio\",\"codec_name\":\"mp3\",\"sample_rate\":\"44100\",\"channels\":2,\"bit_rate\":\"128000\",\"duration\":\"1.0\"}],\"format\":{\"bit_rate\":\"128000\",\"duration\":\"1.0\"}}'\n",
+            "#!/bin/sh\ncase \"$*\" in *track1.mp3*) sleep 1 ;; esac\necho '{\"streams\":[{\"codec_type\":\"audio\",\"codec_name\":\"mp3\",\"sample_rate\":\"44100\",\"channels\":2,\"bit_rate\":\"128000\",\"duration\":\"1.0\"}],\"format\":{\"bit_rate\":\"128000\",\"duration\":\"1.0\"}}'\n",
         )
         .unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&probe, fs::Permissions::from_mode(0o755)).unwrap();
-        }
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&probe, fs::Permissions::from_mode(0o755)).unwrap();
 
         let mut book = BookFolder::new(temp_dir.path().join("Book"));
         book.mp3_files = vec![

--- a/src/core/analyzer.rs
+++ b/src/core/analyzer.rs
@@ -66,9 +66,14 @@ impl Analyzer {
             }
         }
 
-        // Sort tracks by filename (they should already be sorted from scanner)
-        // This is just to ensure consistency
-        tracks.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+        // `buffer_unordered` completes probes out of order. Restore the scanner's
+        // natural order so tracks such as 1, 2, 10 are not emitted as 1, 10, 2.
+        tracks.sort_by(|a, b| {
+            natord::compare(
+                &a.file_path.to_string_lossy(),
+                &b.file_path.to_string_lossy(),
+            )
+        });
 
         book_folder.tracks = tracks;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,7 @@ pub mod extraction;
 pub use config::ConfigManager;
 pub use validation::DependencyChecker;
 pub use sorting::natural_sort;
+pub(crate) use sorting::natural_compare;
 pub use cache::{AudibleCache, CacheStats};
 pub use merge_patterns::{detect_merge_pattern, sort_by_part_number, MergePatternResult, MergePatternType};
 

--- a/src/utils/sorting.rs
+++ b/src/utils/sorting.rs
@@ -13,7 +13,7 @@ pub fn natural_sort<P: AsRef<Path>>(paths: &mut [P]) {
 }
 
 /// Compare two paths using natural ordering
-fn natural_compare(a: &Path, b: &Path) -> Ordering {
+pub(crate) fn natural_compare(a: &Path, b: &Path) -> Ordering {
     let a_str = a.to_string_lossy();
     let b_str = b.to_string_lossy();
 


### PR DESCRIPTION
## Problem

`track1.mp3, track2.mp3, track10.mp3` come out of the analyzer as `track1, track10, track2`. That order feeds the FFmpeg concat list and chapter generation, so the finished audiobook can play chapter 10 before chapter 2.

## Cause

The analyzer probes files concurrently with `buffer_unordered`, which yields them in completion order, then restores order with `PathBuf::cmp` - a lexicographic compare, where `"10" < "2"`.

## Fix

Sort with the same `natural_compare` the scanner already uses. Probing stays concurrent; only the final ordering changes.

## Test

`core::analyzer::tests::analyzed_tracks_keep_the_scanner_natural_order` runs the real analyzer path against a stub ffprobe that delays `track1`, so probes are guaranteed to finish out of order.

Before: `["track1.mp3", "track10.mp3", "track2.mp3"]`
After: `["track1.mp3", "track2.mp3", "track10.mp3"]`

Unix-only, since the stub is a shell script.

---

The 9 failures in the full suite are the pre-existing ffmpeg/ffprobe-dependent tests; they fail on `main` too when those binaries are missing.

