### PR TITLE
fix(batch): honor configured book-worker limit

### DIFF
--- a/src/core/batch.rs
+++ b/src/core/batch.rs
@@ -18,7 +18,7 @@ pub struct BatchProcessor {
     encoder: AacEncoder,
     /// Enable parallel file encoding
     enable_parallel_encoding: bool,
-    /// Maximum concurrent encoding operations (to limit CPU usage)
+    /// Effective maximum number of books processed concurrently
     max_concurrent_encodes: usize,
     /// Maximum concurrent file encodings per book
     max_concurrent_files: usize,
@@ -31,12 +31,15 @@ pub struct BatchProcessor {
 impl BatchProcessor {
     /// Create a new batch processor with default settings
     pub fn new(workers: usize) -> Self {
+        let workers = workers.clamp(1, 16);
         Self {
-            workers: workers.clamp(1, 16),
+            workers,
             keep_temp: false,
             encoder: crate::audio::get_encoder(),
             enable_parallel_encoding: true,
-            max_concurrent_encodes: 2.min(workers.clamp(1, 16)), // Default: 2 concurrent encodes
+            // The default safety cap is two books, or fewer when the worker
+            // count itself is lower.
+            max_concurrent_encodes: 2.min(workers),
             max_concurrent_files: 8, // Default: 8 concurrent files per book
             quality_preset: None,
             retry_config: RetryConfig::new(),
@@ -90,8 +93,8 @@ impl BatchProcessor {
             self.max_concurrent_encodes
         );
 
-        // Create a semaphore to limit concurrent encoding operations
-        let encode_semaphore = Arc::new(Semaphore::new(self.max_concurrent_encodes));
+        // Each permit covers one complete book-processing task.
+        let book_semaphore = Arc::new(Semaphore::new(self.max_concurrent_encodes));
 
         // Create channel for collecting results
         let (result_tx, mut result_rx) = mpsc::channel(total_books);
@@ -108,12 +111,12 @@ impl BatchProcessor {
             let enable_parallel_encoding = self.enable_parallel_encoding;
             let max_concurrent_files = self.max_concurrent_files;
             let quality_preset = self.quality_preset.clone();
-            let encode_semaphore = Arc::clone(&encode_semaphore);
+            let book_semaphore = Arc::clone(&book_semaphore);
             let retry_config = self.retry_config.clone();
 
             let handle = tokio::spawn(async move {
-                // Acquire semaphore permit before encoding (limits concurrent encodes)
-                let _permit = encode_semaphore.acquire().await.unwrap();
+                // Acquire one worker permit for the full lifetime of this book.
+                let _permit = book_semaphore.acquire().await.unwrap();
 
                 tracing::info!(
                     "[{}/{}] Processing: {}",
@@ -252,12 +255,15 @@ mod tests {
     }
 
     #[test]
-    fn test_concurrent_encode_clamping() {
+    fn test_concurrent_encode_and_worker_clamping() {
         let processor = BatchProcessor::with_options(4, false, AacEncoder::Native, true, 0, 8, None, RetryConfig::new());
         assert_eq!(processor.max_concurrent_encodes, 1);
 
-        let processor = BatchProcessor::with_options(4, false, AacEncoder::Native, true, 100, 8, None, RetryConfig::new());
-        assert_eq!(processor.max_concurrent_encodes, 4);
+        let clamped_to_supported_max = BatchProcessor::with_options(16, false, AacEncoder::Native, true, 100, 8, None, RetryConfig::new());
+        assert_eq!(clamped_to_supported_max.max_concurrent_encodes, 16);
+
+        let clamped_to_workers = BatchProcessor::with_options(4, false, AacEncoder::Native, true, 100, 8, None, RetryConfig::new());
+        assert_eq!(clamped_to_workers.max_concurrent_encodes, 4);
     }
 
     #[test]

--- a/src/core/batch.rs
+++ b/src/core/batch.rs
@@ -36,7 +36,7 @@ impl BatchProcessor {
             keep_temp: false,
             encoder: crate::audio::get_encoder(),
             enable_parallel_encoding: true,
-            max_concurrent_encodes: 2, // Default: 2 concurrent encodes
+            max_concurrent_encodes: 2.min(workers.clamp(1, 16)), // Default: 2 concurrent encodes
             max_concurrent_files: 8, // Default: 8 concurrent files per book
             quality_preset: None,
             retry_config: RetryConfig::new(),
@@ -54,12 +54,16 @@ impl BatchProcessor {
         quality_preset: Option<String>,
         retry_config: RetryConfig,
     ) -> Self {
+        let workers = workers.clamp(1, 16);
         Self {
-            workers: workers.clamp(1, 16),
+            workers,
             keep_temp,
             encoder,
             enable_parallel_encoding,
-            max_concurrent_encodes: max_concurrent_encodes.clamp(1, 16),
+            // `workers` is the user-facing batch concurrency setting. The
+            // encoding cap may lower it further, but must never let `-j` be
+            // exceeded.
+            max_concurrent_encodes: max_concurrent_encodes.clamp(1, 16).min(workers),
             max_concurrent_files: max_concurrent_files.clamp(1, 32),
             quality_preset,
             retry_config,
@@ -253,7 +257,23 @@ mod tests {
         assert_eq!(processor.max_concurrent_encodes, 1);
 
         let processor = BatchProcessor::with_options(4, false, AacEncoder::Native, true, 100, 8, None, RetryConfig::new());
-        assert_eq!(processor.max_concurrent_encodes, 16);
+        assert_eq!(processor.max_concurrent_encodes, 4);
+    }
+
+    #[test]
+    fn test_worker_count_limits_batch_encodes() {
+        let processor = BatchProcessor::with_options(
+            1,
+            false,
+            AacEncoder::Native,
+            true,
+            8,
+            8,
+            None,
+            RetryConfig::new(),
+        );
+
+        assert_eq!(processor.max_concurrent_encodes, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`-j` does not limit anything. `audiobook-forge build -j 1` still processes as many books at once as `max_concurrent_encodes` allows - which defaults to `auto`, i.e. one per CPU core.

## Cause

`BatchProcessor` stored `workers` and printed it in the startup log, but the semaphore gating book processing was built from `max_concurrent_encodes` alone. Nothing connected the two.

## Fix

Effective limit = `min(workers, max_concurrent_encodes)`.

- `workers` (`-j`) is the ceiling the user asked for.
- `max_concurrent_encodes` may lower it further, but can no longer raise it.

The semaphore is renamed to `book_semaphore`: one permit covers a whole book, not a single encode, which is what the old name implied.

## Behavior change worth knowing

The default config is `parallel_workers: 2` with `max_concurrent_encodes: auto`. Today that runs one book per core; from here it runs 2 - which is what `-j` always advertised, but it is a throughput drop for anyone who relied on `auto`. Raise `-j` or `parallel_workers` to get the old level back.

## Tests

- `test_worker_count_limits_batch_encodes` - 1 worker, 8 encodes → 1.
- `test_concurrent_encode_and_worker_clamping` - the 1..16 clamp and the worker cap are asserted separately, so neither hides the other.

