### PR TITLE
fix(m4b): reject incompatible streams before lossless concat

### DIFF
--- a/src/core/m4b_merger.rs
+++ b/src/core/m4b_merger.rs
@@ -2,7 +2,7 @@
 
 use crate::audio::{read_m4b_chapters, merge_chapter_lists, Chapter, FFmpeg};
 use crate::audio::{write_mp4box_chapters, inject_chapters_mp4box, inject_metadata_atomicparsley};
-use crate::models::BookFolder;
+use crate::models::{BookFolder, QualityProfile};
 use crate::utils::sort_by_part_number;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -46,6 +46,14 @@ impl M4bMerger {
             m4b_files.len(),
             book_folder.name
         );
+
+        let source_profiles: Vec<QualityProfile> = futures::future::try_join_all(
+            m4b_files
+                .iter()
+                .map(|file| self.ffmpeg.probe_audio_file(file)),
+        )
+        .await
+        .context("Failed to inspect source M4B audio streams")?;
 
         // Create temp directory
         let temp_dir = self.create_temp_dir(&book_folder.name)?;
@@ -102,7 +110,33 @@ impl M4bMerger {
 
         // Step 2: Create concat file for FFmpeg
         let concat_file = temp_dir.join("concat.txt");
-        let file_refs: Vec<&Path> = m4b_files.iter().map(|p| p.as_path()).collect();
+        let concat_inputs = if Self::requires_normalization(&source_profiles) {
+            let target_profile = Self::normalization_profile(&source_profiles);
+            tracing::warn!(
+                "M4B streams differ; normalizing all parts to {} before concatenation",
+                target_profile
+            );
+
+            let mut normalized = Vec::with_capacity(m4b_files.len());
+            for (index, source) in m4b_files.iter().enumerate() {
+                let output = temp_dir.join(format!("normalized-{index:04}.m4a"));
+                self.ffmpeg
+                    .convert_single_file(
+                        source,
+                        &output,
+                        &target_profile,
+                        false,
+                        crate::audio::get_encoder(),
+                    )
+                    .await
+                    .with_context(|| format!("Failed to normalize {}", source.display()))?;
+                normalized.push(output);
+            }
+            normalized
+        } else {
+            m4b_files.clone()
+        };
+        let file_refs: Vec<&Path> = concat_inputs.iter().map(|p| p.as_path()).collect();
         FFmpeg::create_concat_file(&file_refs, &concat_file)?;
 
         // Step 3: Concatenate audio losslessly
@@ -142,6 +176,32 @@ impl M4bMerger {
         tracing::info!("M4B merge complete: {}", output_path.display());
 
         Ok(output_path)
+    }
+
+    /// Whether source streams must be normalized before FFmpeg concat demuxing.
+    /// The concat demuxer accepts incompatible streams without an error, which
+    /// can produce an M4B with incorrect timing or channel parameters.
+    fn requires_normalization(profiles: &[QualityProfile]) -> bool {
+        let Some(first) = profiles.first() else {
+            return false;
+        };
+
+        !matches!(first.codec.to_lowercase().as_str(), "aac" | "alac")
+            || profiles[1..]
+                .iter()
+                .any(|profile| !first.is_compatible_for_concat(profile))
+    }
+
+    /// Choose one lossless-concat-compatible AAC profile that does not lower a
+    /// source stream's bitrate, sample rate, or channel count.
+    fn normalization_profile(profiles: &[QualityProfile]) -> QualityProfile {
+        QualityProfile {
+            bitrate: profiles.iter().map(|p| p.bitrate).max().unwrap_or(128).max(128),
+            sample_rate: profiles.iter().map(|p| p.sample_rate).max().unwrap_or(44_100),
+            channels: profiles.iter().map(|p| p.channels).max().unwrap_or(2),
+            codec: "aac".to_string(),
+            duration: 0.0,
+        }
     }
 
     /// Synthesize a single chapter spanning the full duration of a source file.

--- a/src/core/m4b_merger.rs
+++ b/src/core/m4b_merger.rs
@@ -223,3 +223,20 @@ impl Default for M4bMerger {
         Self::new().expect("Failed to create M4B merger")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::QualityProfile;
+
+    #[test]
+    fn incompatible_streams_require_normalization_before_concat() {
+        let mono_44khz = QualityProfile::new(64, 44_100, 1, "aac".to_string(), 1.0).unwrap();
+        let stereo_48khz = QualityProfile::new(128, 48_000, 2, "aac".to_string(), 1.0).unwrap();
+
+        assert!(M4bMerger::requires_normalization(&[
+            mono_44khz,
+            stereo_48khz,
+        ]));
+    }
+}

--- a/src/core/m4b_merger.rs
+++ b/src/core/m4b_merger.rs
@@ -110,10 +110,11 @@ impl M4bMerger {
 
         // Step 2: Create concat file for FFmpeg
         let concat_file = temp_dir.join("concat.txt");
-        let concat_inputs = if Self::requires_normalization(&source_profiles) {
+        let requires_normalization = Self::requires_normalization(&source_profiles);
+        let concat_inputs = if requires_normalization {
             let target_profile = Self::normalization_profile(&source_profiles);
             tracing::warn!(
-                "M4B streams differ; normalizing all parts to {} before concatenation",
+                "M4B stream formats differ; normalizing all parts to {} before concatenation. Temporary disk usage may approach the total source size",
                 target_profile
             );
 
@@ -143,7 +144,11 @@ impl M4bMerger {
         let output_filename = book_folder.get_output_filename();
         let output_path = output_dir.join(&output_filename);
 
-        tracing::info!("Concatenating audio (lossless copy mode)...");
+        if requires_normalization {
+            tracing::info!("Concatenating normalized audio streams...");
+        } else {
+            tracing::info!("Concatenating audio (lossless copy mode)...");
+        }
 
         self.ffmpeg
             .concat_m4b_files(&concat_file, &output_path)
@@ -189,11 +194,19 @@ impl M4bMerger {
         !matches!(first.codec.to_lowercase().as_str(), "aac" | "alac")
             || profiles[1..]
                 .iter()
-                .any(|profile| !first.is_compatible_for_concat(profile))
+                .any(|profile| !Self::is_copy_compatible(first, profile))
     }
 
-    /// Choose one lossless-concat-compatible AAC profile that does not lower a
-    /// source stream's bitrate, sample rate, or channel count.
+    /// FFmpeg copy-concat requires stable stream structure, but measured average
+    /// bitrate may legitimately differ between otherwise compatible VBR parts.
+    fn is_copy_compatible(first: &QualityProfile, other: &QualityProfile) -> bool {
+        first.sample_rate == other.sample_rate
+            && first.channels == other.channels
+            && first.codec.eq_ignore_ascii_case(&other.codec)
+    }
+
+    /// Choose one concat-compatible AAC profile that does not lower a source
+    /// stream's bitrate, sample rate, or channel count.
     fn normalization_profile(profiles: &[QualityProfile]) -> QualityProfile {
         QualityProfile {
             bitrate: profiles.iter().map(|p| p.bitrate).max().unwrap_or(128).max(128),
@@ -298,5 +311,21 @@ mod tests {
             mono_44khz,
             stereo_48khz,
         ]));
+    }
+
+    #[test]
+    fn compatible_vbr_streams_keep_copy_concat() {
+        let part1 = QualityProfile::new(62, 48_000, 2, "aac".to_string(), 1.0).unwrap();
+        let part2 = QualityProfile::new(63, 48_000, 2, "aac".to_string(), 1.0).unwrap();
+
+        assert!(!M4bMerger::requires_normalization(&[part1, part2]));
+    }
+
+    #[test]
+    fn compatible_surround_streams_keep_copy_concat() {
+        let part1 = QualityProfile::new(256, 48_000, 6, "aac".to_string(), 1.0).unwrap();
+        let part2 = QualityProfile::new(255, 48_000, 6, "aac".to_string(), 1.0).unwrap();
+
+        assert!(!M4bMerger::requires_normalization(&[part1, part2]));
     }
 }

--- a/src/core/m4b_merger.rs
+++ b/src/core/m4b_merger.rs
@@ -54,6 +54,7 @@ impl M4bMerger {
         )
         .await
         .context("Failed to inspect source M4B audio streams")?;
+        Self::validate_copy_compatibility(&source_profiles)?;
 
         // Create temp directory
         let temp_dir = self.create_temp_dir(&book_folder.name)?;
@@ -110,45 +111,14 @@ impl M4bMerger {
 
         // Step 2: Create concat file for FFmpeg
         let concat_file = temp_dir.join("concat.txt");
-        let requires_normalization = Self::requires_normalization(&source_profiles);
-        let concat_inputs = if requires_normalization {
-            let target_profile = Self::normalization_profile(&source_profiles);
-            tracing::warn!(
-                "M4B stream formats differ; normalizing all parts to {} before concatenation. Temporary disk usage may approach the total source size",
-                target_profile
-            );
-
-            let mut normalized = Vec::with_capacity(m4b_files.len());
-            for (index, source) in m4b_files.iter().enumerate() {
-                let output = temp_dir.join(format!("normalized-{index:04}.m4a"));
-                self.ffmpeg
-                    .convert_single_file(
-                        source,
-                        &output,
-                        &target_profile,
-                        false,
-                        crate::audio::get_encoder(),
-                    )
-                    .await
-                    .with_context(|| format!("Failed to normalize {}", source.display()))?;
-                normalized.push(output);
-            }
-            normalized
-        } else {
-            m4b_files.clone()
-        };
-        let file_refs: Vec<&Path> = concat_inputs.iter().map(|p| p.as_path()).collect();
+        let file_refs: Vec<&Path> = m4b_files.iter().map(|p| p.as_path()).collect();
         FFmpeg::create_concat_file(&file_refs, &concat_file)?;
 
         // Step 3: Concatenate audio losslessly
         let output_filename = book_folder.get_output_filename();
         let output_path = output_dir.join(&output_filename);
 
-        if requires_normalization {
-            tracing::info!("Concatenating normalized audio streams...");
-        } else {
-            tracing::info!("Concatenating audio (lossless copy mode)...");
-        }
+        tracing::info!("Concatenating audio (lossless copy mode)...");
 
         self.ffmpeg
             .concat_m4b_files(&concat_file, &output_path)
@@ -183,18 +153,37 @@ impl M4bMerger {
         Ok(output_path)
     }
 
-    /// Whether source streams must be normalized before FFmpeg concat demuxing.
+    /// Reject streams that cannot be safely passed to FFmpeg copy-concat.
     /// The concat demuxer accepts incompatible streams without an error, which
     /// can produce an M4B with incorrect timing or channel parameters.
-    fn requires_normalization(profiles: &[QualityProfile]) -> bool {
+    fn validate_copy_compatibility(profiles: &[QualityProfile]) -> Result<()> {
         let Some(first) = profiles.first() else {
-            return false;
+            anyhow::bail!("No M4B audio streams were found to concatenate");
         };
 
-        !matches!(first.codec.to_lowercase().as_str(), "aac" | "alac")
-            || profiles[1..]
-                .iter()
-                .any(|profile| !Self::is_copy_compatible(first, profile))
+        if !matches!(first.codec.to_lowercase().as_str(), "aac" | "alac") {
+            anyhow::bail!(
+                "M4B stream codec '{}' cannot be concatenated losslessly; normalize the source files first",
+                first.codec
+            );
+        }
+
+        if let Some(incompatible) = profiles[1..]
+            .iter()
+            .find(|profile| !Self::is_copy_compatible(first, profile))
+        {
+            anyhow::bail!(
+                "M4B audio streams are incompatible for lossless concatenation (first: {} Hz/{} ch/{}, incompatible: {} Hz/{} ch/{}); normalize the source files first",
+                first.sample_rate,
+                first.channels,
+                first.codec,
+                incompatible.sample_rate,
+                incompatible.channels,
+                incompatible.codec
+            );
+        }
+
+        Ok(())
     }
 
     /// FFmpeg copy-concat requires stable stream structure, but measured average
@@ -203,18 +192,6 @@ impl M4bMerger {
         first.sample_rate == other.sample_rate
             && first.channels == other.channels
             && first.codec.eq_ignore_ascii_case(&other.codec)
-    }
-
-    /// Choose one concat-compatible AAC profile that does not lower a source
-    /// stream's bitrate, sample rate, or channel count.
-    fn normalization_profile(profiles: &[QualityProfile]) -> QualityProfile {
-        QualityProfile {
-            bitrate: profiles.iter().map(|p| p.bitrate).max().unwrap_or(128).max(128),
-            sample_rate: profiles.iter().map(|p| p.sample_rate).max().unwrap_or(44_100),
-            channels: profiles.iter().map(|p| p.channels).max().unwrap_or(2),
-            codec: "aac".to_string(),
-            duration: 0.0,
-        }
     }
 
     /// Synthesize a single chapter spanning the full duration of a source file.
@@ -303,14 +280,11 @@ mod tests {
     use crate::models::QualityProfile;
 
     #[test]
-    fn incompatible_streams_require_normalization_before_concat() {
+    fn incompatible_streams_are_rejected_before_concat() {
         let mono_44khz = QualityProfile::new(64, 44_100, 1, "aac".to_string(), 1.0).unwrap();
         let stereo_48khz = QualityProfile::new(128, 48_000, 2, "aac".to_string(), 1.0).unwrap();
 
-        assert!(M4bMerger::requires_normalization(&[
-            mono_44khz,
-            stereo_48khz,
-        ]));
+        assert!(M4bMerger::validate_copy_compatibility(&[mono_44khz, stereo_48khz]).is_err());
     }
 
     #[test]
@@ -318,7 +292,7 @@ mod tests {
         let part1 = QualityProfile::new(62, 48_000, 2, "aac".to_string(), 1.0).unwrap();
         let part2 = QualityProfile::new(63, 48_000, 2, "aac".to_string(), 1.0).unwrap();
 
-        assert!(!M4bMerger::requires_normalization(&[part1, part2]));
+        assert!(M4bMerger::validate_copy_compatibility(&[part1, part2]).is_ok());
     }
 
     #[test]
@@ -326,6 +300,6 @@ mod tests {
         let part1 = QualityProfile::new(256, 48_000, 6, "aac".to_string(), 1.0).unwrap();
         let part2 = QualityProfile::new(255, 48_000, 6, "aac".to_string(), 1.0).unwrap();
 
-        assert!(!M4bMerger::requires_normalization(&[part1, part2]));
+        assert!(M4bMerger::validate_copy_compatibility(&[part1, part2]).is_ok());
     }
 }

--- a/src/models/quality.rs
+++ b/src/models/quality.rs
@@ -10,7 +10,7 @@ pub struct QualityProfile {
     pub bitrate: u32,
     /// Sample rate in Hz
     pub sample_rate: u32,
-    /// Number of channels (1=mono, 2=stereo)
+    /// Number of audio channels (1=mono, 2=stereo, higher=surround)
     pub channels: u8,
     /// Audio codec (e.g., "mp3", "aac")
     pub codec: String,
@@ -27,8 +27,8 @@ impl QualityProfile {
         if sample_rate == 0 {
             anyhow::bail!("Sample rate must be positive, got {}", sample_rate);
         }
-        if channels != 1 && channels != 2 {
-            anyhow::bail!("Channels must be 1 or 2, got {}", channels);
+        if channels == 0 {
+            anyhow::bail!("Channels must be positive, got {}", channels);
         }
 
         Ok(Self {
@@ -172,7 +172,8 @@ mod tests {
     fn test_quality_validation() {
         assert!(QualityProfile::new(0, 44100, 2, "aac".to_string(), 3600.0).is_err());
         assert!(QualityProfile::new(128, 0, 2, "aac".to_string(), 3600.0).is_err());
-        assert!(QualityProfile::new(128, 44100, 3, "aac".to_string(), 3600.0).is_err());
+        assert!(QualityProfile::new(128, 44100, 0, "aac".to_string(), 3600.0).is_err());
+        assert!(QualityProfile::new(128, 48000, 6, "aac".to_string(), 3600.0).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The M4B merger always concatenates with `-c copy`. Give it one 44.1 kHz mono part and one 48 kHz stereo part and FFmpeg still exits 0 - but the result can have wrong duration, timing, or channel interpretation. Audiobook Forge reports success over a broken file.

## Cause

The normal processing path checks stream compatibility before choosing copy mode. The dedicated multi-M4B path skips it, assuming a shared container means a shared stream format. M4B is only the container.

## Fix

Probe every source up front and refuse the merge, with a message naming the mismatch, when the parts cannot be copy-concatenated:

- the codec must be AAC or ALAC, and
- sample rate, channel count and codec must match across all parts.

Bitrate is deliberately **not** compared. ffprobe reports measured average bitrate, so two VBR parts from the same encode routinely differ by 1 kbps while being perfectly concat-compatible - comparing it would re-encode almost every real merge.

A clear error that says "normalize these files first" is better than a silently mistimed audiobook. The failure is per book: other books in the run continue.

## Side change

`QualityProfile::new` accepted only 1 or 2 channels and errored on anything else. It now accepts any positive count, so surround sources reach this check (and the normal encode path) instead of failing during probing.

## Tests

- `incompatible_streams_are_rejected_before_concat` - 44.1 kHz mono + 48 kHz stereo → error.
- `compatible_vbr_streams_keep_copy_concat` - 62 vs 63 kbps, same format → still lossless copy.
- `compatible_surround_streams_keep_copy_concat` - 6-channel parts → still lossless copy.

